### PR TITLE
fix(yarn): Make install command a bit more flexible

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -51,12 +51,12 @@ jobs:
 
       - name: Install caller packages
         if: ${{ inputs.install-from-caller }}
-        run: yarn install --frozen-lockfile
+        run: yarn install
 
       - name: Install tooling packages
         if: ${{ !inputs.install-from-caller }}
         working-directory: .tooling
-        run: yarn install --frozen-lockfile
+        run: yarn install
 
       - name: Run Danger
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
Prompted by the incident, when [migrating volt](https://github.com/artsy/volt/pull/9905) to yarn 4 we [started getting errors](https://github.com/artsy/volt/actions/runs/17568411196/job/49899772251?pr=9905) during the install step due to `--frozen-lockfile` being deprecated (yarn 4 uses `--immutable`). So this removes it for now as we continue the migration, so that things work across both yarn package manager versions. 

This increases the possibility that we'll get a cache miss during the install step when running the job, but practically speaking this will be rare, because this repos dependencies are slender and transitive deps will likely not change frequently. (Eventually we _will_ want to switch it back to `--immutable` tho.)