### PR TITLE
fix(danger): Ensure that we can successfully execute in yarn 1/4 environments

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -1,0 +1,46 @@
+name: 'Setup Node and Install Dependencies'
+description: 'Sets up Node.js and installs dependencies with Yarn version detection'
+inputs:
+  node-version:
+    description: 'Node.js version to use'
+    required: false
+    default: '22'
+  install-from-caller:
+    description: 'Whether to install from caller directory or tooling directory'
+    required: false
+    default: 'false'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: yarn
+        cache-dependency-path: |
+          yarn.lock
+          .tooling/yarn.lock
+
+    - name: Install packages
+      shell: bash
+      run: |
+        # Determine which directory to install in
+        if [ "${{ inputs.install-from-caller }}" == "true" ]; then
+          INSTALL_DIR="."
+        else
+          INSTALL_DIR=".tooling"
+        fi
+        
+        echo "Installing packages in: $INSTALL_DIR"
+        cd "$INSTALL_DIR"
+        
+        # Detect Yarn version and install with appropriate flags
+        if [ -f ".yarnrc.yml" ]; then
+          # Yarn 2+ (Berry)
+          echo "Detected Yarn 2+ (Berry), using --immutable flag"
+          yarn install --immutable
+        else
+          # Yarn 1 (Classic)
+          echo "Detected Yarn 1 (Classic), using --frozen-lockfile flag"
+          yarn install --frozen-lockfile
+        fi

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -40,37 +40,11 @@ jobs:
           ref: main
           path: .tooling
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup Node and Install Dependencies
+        uses: ./.tooling/.github/actions/setup-and-install
         with:
-          node-version: "${{ inputs.node-version }}"
-          cache: yarn
-          cache-dependency-path: |
-            yarn.lock
-            .tooling/yarn.lock
-
-      - name: Install caller packages
-        if: ${{ inputs.install-from-caller }}
-        run: |
-          if [ -f ".yarnrc.yml" ]; then
-            # Yarn 2+ (Berry)
-            yarn install --immutable
-          else
-            # Yarn 1 (Classic)
-            yarn install --frozen-lockfile
-          fi
-
-      - name: Install tooling packages
-        if: ${{ !inputs.install-from-caller }}
-        working-directory: .tooling
-        run: |
-          if [ -f ".yarnrc.yml" ]; then
-            # Yarn 2+ (Berry)
-            yarn install --immutable
-          else
-            # Yarn 1 (Classic)
-            yarn install --frozen-lockfile
-          fi
+          node-version: ${{ inputs.node-version }}
+          install-from-caller: ${{ inputs.install-from-caller }}
 
       - name: Run Danger
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -51,12 +51,26 @@ jobs:
 
       - name: Install caller packages
         if: ${{ inputs.install-from-caller }}
-        run: yarn install
+        run: |
+          if [ -f ".yarnrc.yml" ]; then
+            # Yarn 2+ (Berry)
+            yarn install --immutable
+          else
+            # Yarn 1 (Classic)
+            yarn install --frozen-lockfile
+          fi
 
       - name: Install tooling packages
         if: ${{ !inputs.install-from-caller }}
         working-directory: .tooling
-        run: yarn install
+        run: |
+          if [ -f ".yarnrc.yml" ]; then
+            # Yarn 2+ (Berry)
+            yarn install --immutable
+          else
+            # Yarn 1 (Classic)
+            yarn install --frozen-lockfile
+          fi
 
       - name: Run Danger
         working-directory: ${{ github.workspace }}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "license": "MIT",
   "private": true,
+  "devDependencies": {
+    "@types/node": "^24.3.1"
+  },
   "dependencies": {
     "danger": "^13.0.4",
     "danger-plugin-yarn": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,6 +266,13 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
+"@types/node@^24.3.1":
+  version "24.3.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.3.1.tgz#b0a3fb2afed0ef98e8d7f06d46ef6349047709f3"
+  integrity sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==
+  dependencies:
+    undici-types "~7.10.0"
+
 acorn-walk@^8.1.1:
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
@@ -958,6 +965,11 @@ typescript@^5.9.2:
   version "5.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
   integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
+
+undici-types@~7.10.0:
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.10.0.tgz#4ac2e058ce56b462b056e629cc6a02393d3ff350"
+  integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
 
 universal-user-agent@^6.0.0:
   version "6.0.1"


### PR DESCRIPTION
Quick follow-up to https://github.com/artsy/duchamp/pull/4. 

After updating we were still getting errors from the above:

```bash
[run-danger/Danger Checks/run] ➤ YN0000: · Yarn 4.9.4
[run-danger/Danger Checks/run] ➤ YN0000: ┌ Resolution step
[run-danger/Danger Checks/run]   ❓  ::group::Resolution step
[run-danger/Danger Checks/run] ➤ YN0085: │ + danger-plugin-yarn@npm:1.6.0, danger@npm:13.0.4, ts-node@npm:10.9.2, and 146 more.
[run-danger/Danger Checks/run]   ❓  ::endgroup::
[run-danger/Danger Checks/run] ➤ YN0000: └ Completed in 6s 378ms
[run-danger/Danger Checks/run] ➤ YN0000: ┌ Post-resolution validation
[run-danger/Danger Checks/run]   ❓  ::group::Post-resolution validation
[run-danger/Danger Checks/run] ➤ YN0002: │ duchamp@workspace:. doesn't provide @types/node (pffc832), requested by ts-node.
[run-danger/Danger Checks/run] ➤ YN0086: │ Some peer dependencies are incorrectly met by your project; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
[run-danger/Danger Checks/run] ➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
[run-danger/Danger Checks/run]   ❓  ::endgroup::
[run-danger/Danger Checks/run] ➤ YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
[run-danger/Danger Checks/run] ➤ YN0000: └ Completed
[run-danger/Danger Checks/run] ➤ YN0000: · Failed with errors in 6s 392ms
[run-danger/Danger Checks/run]   ❌  Failure - Main Install tooling packages [6.667729958s]
[run-danger/Danger Checks/run] exitcode '1': failure
```

So this fixes things to check if we're in a modern/legacy yarn environment (yaml == modern) and if so, execute the appropriate command. 

Additionally, installs a missing package: @types/node, which is a peerDependency. 
