### PR TITLE
feat: support RFC titles in conventional commits check

### DIFF
--- a/.github/workflows/conventional-commits-check.yml
+++ b/.github/workflows/conventional-commits-check.yml
@@ -17,7 +17,8 @@ jobs:
             const title = pr.title;
             const conventionalCommitFormat = /^(fix|feat|build|chore|ci|docs|style|refactor|perf|test|revert)(?:\(.+\))?!?:.+$/;
             const githubRevertFormat = /^Revert.*/;
-            const titlePasses = title === 'Deploy' || githubRevertFormat.test(title) || conventionalCommitFormat.test(title);
+            const rfcFormat = /^RFC:.+$/;
+            const titlePasses = title === 'Deploy' || githubRevertFormat.test(title) || conventionalCommitFormat.test(title) || rfcFormat.test(title);
 
             if (titlePasses) {
               console.log("Conventional commit check passed.");


### PR DESCRIPTION
This PR adds a check to allow our standard rfc PR title to pass our conventional commits check. RFC titles should not be failing, as is [currently happening](https://github.com/artsy/README/actions/runs/26537466151/job/78170043084?pr=582).