### PR TITLE
fix: correctly install Yarn 1 dependencies in CI when Yarn 4 is available globally

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -17,12 +17,14 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
     - name: Cache Yarn packages
       uses: actions/cache@v4
       with:
-        path: |
-          ~/.cache/yarn/v6
-          ~/.yarn/berry/cache
+        path: ~/.cache/yarn/v6
         key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', '.tooling/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-

--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -24,6 +24,8 @@ runs:
           ~/.cache/yarn/v6
           ~/.yarn/berry/cache
         key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', '.tooling/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     - name: Install packages
       shell: bash

--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -16,10 +16,14 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: yarn
-        cache-dependency-path: |
-          yarn.lock
-          .tooling/yarn.lock
+
+    - name: Cache Yarn packages
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/yarn/v6
+          ~/.yarn/berry/cache
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', '.tooling/yarn.lock') }}
 
     - name: Install packages
       shell: bash
@@ -33,6 +37,13 @@ runs:
 
         echo "Installing packages in: $INSTALL_DIR"
         cd "$INSTALL_DIR"
+
+        # Activate the packageManager version via corepack so the global Yarn isn't used instead of the project's version
+        PKG_MANAGER=$(node -e "try{process.stdout.write(require('./package.json').packageManager||'')}catch(e){}" 2>/dev/null || echo "")
+        if [[ -n "$PKG_MANAGER" && "$PKG_MANAGER" =~ ^yarn@ ]]; then
+          echo "Activating $PKG_MANAGER via corepack"
+          corepack prepare "$PKG_MANAGER" --activate
+        fi
 
         # Detect Yarn version and install with appropriate flags
         YARN_VERSION=$(yarn --version)


### PR DESCRIPTION
This PR updates the `setup-and-install` action that runs in the `run-danger-yarn` workflow so that it correctly installs dependencies with Yarn 1, even though the CI environment has Yarn 4 available globally.

This is done by explicitly activating the correct Yarn version via Corepack before installing, so the project's Yarn 1 is used rather than the globally installed Yarn 4.

There are also 2 other optimizations made in this PR:

1. Cache the Yarn 1 package folder so that CI doesn't have to download dependencies from scratch on every run.
2. Enable Corepack inside the action itself so it is self-contained and doesn't rely on the caller having already
   run it.

The motivation for this change was receiving the following failure in the `run-danger-yarn` workflow after upgrading danger to 13.0.10 in #76:

**Setup Node and Install Dependencies**
```
Prepare all required actions
Getting action download info
Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
Run ./.tooling/.github/actions/setup-and-install
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
Run actions/setup-node@v4
Found in cache @ /opt/hostedtoolcache/node/22.23.0/x64
(node:2415) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Environment details
/usr/local/bin/yarn --version
/usr/local/bin/yarn --version
! Corepack is about to download https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz
4.10.3
/usr/local/bin/yarn config get cacheFolder
4.10.3
/usr/local/bin/yarn config get cacheFolder
/home/runner/.yarn/berry/cache
/home/runner/.yarn/berry/cache
/usr/local/bin/yarn config get enableGlobalCache
/usr/local/bin/yarn config get enableGlobalCache
true
true
yarn cache is not found
Run # Determine which directory to install in
Installing packages in: .tooling
Detected Yarn 4.10.3 (Berry)
➤ YN0000: Yarn detected that the current workflow is executed from a public pull request. For safety the hardened mode has been enabled.
➤ YN0000: It will prevent malicious lockfile manipulations, in exchange for a slower install time. You can opt-out if necessary; check our documentation for more details.

➤ YN0000: · Yarn 4.10.3
➤ YN0000: ┌ Resolution step
Resolution step
  ➤ YN0082: │ danger@npm:13.0.10: No candidates found
➤ YN0082: danger@npm:13.0.10: No candidates found
➤ YN0000: └ Completed in 2s 318ms
➤ YN0000: · Failed with errors in 2s 334ms
Error: Process completed with exit code 1.
```

This shows that CI is using Yarn 4 despite the project being configured for Yarn 1, and Yarn 4 refusing to resolve packages from a Yarn 1 lockfile."

🤖 Generated with [Claude Code](https://claude.com/claude-code)