### PR TITLE
fix: use npx to invoke correct Yarn version instead of relying on Corepack PATH shims

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -17,10 +17,6 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - name: Enable Corepack
-      shell: bash
-      run: corepack enable
-
     - name: Cache Yarn packages
       uses: actions/cache@v4
       with:
@@ -42,21 +38,23 @@ runs:
         echo "Installing packages in: $INSTALL_DIR"
         cd "$INSTALL_DIR"
 
-        # Activate the packageManager version via corepack so the global Yarn isn't used instead of the project's version
+        # Detect the Yarn version from the packageManager field and install with appropriate flags.
+        # For Yarn 1, npx is used to invoke the exact version rather than the global Yarn binary.
         PKG_MANAGER=$(node -e "try{process.stdout.write(require('./package.json').packageManager||'')}catch(e){}" 2>/dev/null || echo "")
-        if [[ -n "$PKG_MANAGER" && "$PKG_MANAGER" =~ ^yarn@ ]]; then
-          echo "Activating $PKG_MANAGER via corepack"
-          corepack prepare "$PKG_MANAGER" --activate
-        fi
 
-        # Detect Yarn version and install with appropriate flags
-        YARN_VERSION=$(yarn --version)
-        if [[ "$YARN_VERSION" =~ ^[234] ]]; then
-          # Yarn 2+ (Berry)
-          echo "Detected Yarn $YARN_VERSION (Berry)"
+        if [[ "$PKG_MANAGER" =~ ^yarn@1 ]]; then
+          echo "Detected Yarn 1 (Classic)"
+          npx --yes "$PKG_MANAGER" install --frozen-lockfile
+        elif [[ -n "$PKG_MANAGER" && "$PKG_MANAGER" =~ ^yarn@ ]]; then
+          echo "Detected Yarn (Berry)"
           yarn install --no-immutable
         else
-          # Yarn 1 (Classic)
-          echo "Detected Yarn $YARN_VERSION (Classic)"
-          yarn install --frozen-lockfile
+          YARN_VERSION=$(yarn --version)
+          if [[ "$YARN_VERSION" =~ ^[234] ]]; then
+            echo "Detected Yarn $YARN_VERSION (Berry)"
+            yarn install --no-immutable
+          else
+            echo "Detected Yarn $YARN_VERSION (Classic)"
+            yarn install --frozen-lockfile
+          fi
         fi

--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -42,7 +42,7 @@ runs:
         # For Yarn 1, npx is used to invoke the exact version rather than the global Yarn binary.
         PKG_MANAGER=$(node -e "try{process.stdout.write(require('./package.json').packageManager||'')}catch(e){}" 2>/dev/null || echo "")
 
-        if [[ "$PKG_MANAGER" =~ ^yarn@1 ]]; then
+        if [[ "$PKG_MANAGER" =~ ^yarn@1\. ]]; then
           echo "Detected Yarn 1 (Classic)"
           npx --yes "${PKG_MANAGER%%+*}" install --frozen-lockfile
         elif [[ -n "$PKG_MANAGER" && "$PKG_MANAGER" =~ ^yarn@ ]]; then

--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -44,7 +44,7 @@ runs:
 
         if [[ "$PKG_MANAGER" =~ ^yarn@1 ]]; then
           echo "Detected Yarn 1 (Classic)"
-          npx --yes "$PKG_MANAGER" install --frozen-lockfile
+          npx --yes "${PKG_MANAGER%%+*}" install --frozen-lockfile
         elif [[ -n "$PKG_MANAGER" && "$PKG_MANAGER" =~ ^yarn@ ]]; then
           echo "Detected Yarn (Berry)"
           yarn install --no-immutable


### PR DESCRIPTION
The approach in #77 of using `corepack prepare --activate` to route `yarn` to the correct version did not work. Each step in a composite action runs in a fresh shell, so PATH changes made by `corepack enable` do not carry over to subsequent steps. As a result, `yarn --version` still returned 4.10.3 despite the activation.

This PR replaces that approach with `npx --yes yarn@<version>` for Yarn 1 projects. `npx` fetches and runs the exact version specified in the `packageManager` field directly, without depending on PATH or Corepack shim setup.

For Berry projects, the system `yarn` is still used since Berry repos typically manage their own Yarn binary locally. For projects with no `packageManager` field, the existing version detection fallback is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)