### PR TITLE
fix: invoke yarn.js directly with node to bypass Corepack shim interception

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -38,13 +38,13 @@ runs:
         echo "Installing packages in: $INSTALL_DIR"
         cd "$INSTALL_DIR"
 
-        # Detect the Yarn version from the packageManager field and install with appropriate flags.
-        # For Yarn 1, npx is used to invoke the exact version rather than the global Yarn binary.
         PKG_MANAGER=$(node -e "try{process.stdout.write(require('./package.json').packageManager||'')}catch(e){}" 2>/dev/null || echo "")
 
         if [[ "$PKG_MANAGER" =~ ^yarn@1\. ]]; then
           echo "Detected Yarn 1 (Classic)"
-          npx --yes "${PKG_MANAGER%%+*}" install --frozen-lockfile
+          YARN_SPEC="${PKG_MANAGER%%+*}"
+          npm install --no-save --prefix /tmp/yarn-classic "$YARN_SPEC"
+          node /tmp/yarn-classic/node_modules/yarn/bin/yarn.js install --frozen-lockfile
         elif [[ -n "$PKG_MANAGER" && "$PKG_MANAGER" =~ ^yarn@ ]]; then
           echo "Detected Yarn (Berry)"
           yarn install --no-immutable


### PR DESCRIPTION
`npx yarn@1.22.22` was still running Yarn 4.10.3 because Corepack intercepts named `yarn` commands — even those invoked via npx — and routes them to the global version.

This PR replaces `npx` with a two-step approach: install Yarn 1 to a temp location with npm, then invoke `yarn.js` directly with `node`. Since Corepack only intercepts named package manager commands and not arbitrary Node.js script executions, this bypasses the shim entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)