### PR TITLE
fix: upgrade danger to 13.0.8

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -24,6 +24,7 @@ runs:
     - name: Install packages
       shell: bash
       run: |
+        # Determine which directory to install in
         if [ "${{ inputs.install-from-caller }}" == "true" ]; then
           INSTALL_DIR="."
         else
@@ -33,19 +34,14 @@ runs:
         echo "Installing packages in: $INSTALL_DIR"
         cd "$INSTALL_DIR"
 
-        echo "=== Yarn diagnostics ==="
-        echo "which yarn: $(which yarn)"
-        echo "yarn --version: $(yarn --version)"
-        echo "corepack --version: $(corepack --version)"
-        echo "packageManager field: $(node -e "console.log(require('./package.json').packageManager)")"
-        echo "COREPACK_ENABLE_STRICT: $COREPACK_ENABLE_STRICT"
-        echo "========================"
-
+        # Detect Yarn version and install with appropriate flags
         YARN_VERSION=$(yarn --version)
         if [[ "$YARN_VERSION" =~ ^[234] ]]; then
+          # Yarn 2+ (Berry)
           echo "Detected Yarn $YARN_VERSION (Berry)"
           yarn install --no-immutable
         else
+          # Yarn 1 (Classic)
           echo "Detected Yarn $YARN_VERSION (Classic)"
           yarn install --frozen-lockfile
         fi

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@notionhq/client": "^2.2.2",
-    "danger": "13.0.10",
+    "danger": "13.0.8",
     "danger-plugin-yarn": "1.6.0",
     "js-yaml": "^4.1.1",
     "ts-node": "10.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,6 +1225,11 @@ acorn@^8.11.0, acorn@^8.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
 ansi-escapes@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -1580,10 +1585,10 @@ danger-plugin-yarn@1.6.0:
     node-fetch "^2.6.0"
     semver "^5.4.1"
 
-danger@13.0.10:
-  version "13.0.10"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-13.0.10.tgz#bddffea497cabd6f02ec127bab06f94693cf6bb0"
-  integrity sha512-qMa/YdfVP/a1HhuvMUsocTO0otgLphuiV5z4G5P7C4+qHvNtCSlzvZm3UuwBut2iwQ/r5NGcwcmD4t+8LjIS0A==
+danger@13.0.8:
+  version "13.0.8"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-13.0.8.tgz#95704e419bc1bed74401f557d15bcfaa9c9243cd"
+  integrity sha512-j2UCsgtcjTuftJ79+W9N8UGdIKBrCjTYqrjVf7rpqRaZBfi/VqKVvzWnTxFrj25Gt5YCwbRaY3+cG7tovV3Vtg==
   dependencies:
     "@gitbeaker/rest" "^38.0.0"
     "@octokit/rest" "^20.1.2"
@@ -1593,6 +1598,8 @@ danger@13.0.10:
     core-js "^3.8.2"
     debug "^4.1.1"
     fast-json-patch "^3.0.0-1"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.2"
     hyperlinker "^1.0.0"
     ini "^5.0.0"
     json5 "^2.2.3"
@@ -1605,6 +1612,7 @@ danger@13.0.10:
     memfs-or-file-map-to-github-branch "^1.3.0"
     micromatch "^4.0.4"
     node-cleanup "^2.1.2"
+    node-fetch "^2.6.7"
     override-require "^1.1.1"
     parse-diff "^0.7.0"
     parse-github-url "^1.0.2"
@@ -1615,24 +1623,23 @@ danger@13.0.10:
     regenerator-runtime "^0.13.9"
     require-from-string "^2.0.2"
     supports-hyperlinks "^4.3.0"
-    undici "6.21.1"
 
 date-fns@^1.28.5:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@^4.1.0, debug@^4.3.1:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
-
-debug@^4.1.1:
+debug@4, debug@^4.1.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
+  dependencies:
+    ms "^2.1.3"
+
+debug@^4.1.0, debug@^4.3.1, debug@^4.3.4:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
@@ -1982,6 +1989,22 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+http-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
+https-proxy-agent@^7.0.2:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -2733,7 +2756,7 @@ node-cleanup@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -3296,11 +3319,6 @@ undici-types@~7.13.0:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.13.0.tgz#a20ba7c0a2be0c97bd55c308069d29d167466bff"
   integrity sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==
-
-undici@6.21.1:
-  version "6.21.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
-  integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
 
 undici@^5.25.4, undici@^5.28.5:
   version "5.29.0"


### PR DESCRIPTION
## Summary

Upgrades `danger` from `13.0.4` to `13.0.8` to fix `ERR_STREAM_PREMATURE_CLOSE` errors from GitHub's API.

## Why 13.0.8

- `13.0.5` replaced `get-stdin` with native Node.js stream consumers, which is the fix for the premature close errors
- `13.0.10` (the version we tried previously) has been quarantined on npm and cannot be installed
- `13.0.8` is the most recent non-quarantined version

🤖 Generated with [Claude Code](https://claude.com/claude-code)