### PR TITLE
fix: pin Node to 22.22.0 in danger workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,7 +11,7 @@ on:
         required: false
         type: string
       node-version:
-        default: "22"
+        default: "22.22.0"
         required: false
         type: string
       install-from-caller:


### PR DESCRIPTION
## Summary

Pins the Node.js version in the danger workflow to `22.22.0`.

## Why

Node `22.23.0` (a security release) changed `http.Agent` so that idle keep-alive sockets retain a `data` listener. This causes `node-fetch@2` to incorrectly throw `ERR_STREAM_PREMATURE_CLOSE` on healthy responses from the GitHub API — which breaks all danger runs before the Dangerfile even executes.

`22.22.0` is the last version before the breaking change. Tracking upstream fix in [danger/danger-js#1515](https://github.com/danger/danger-js/issues/1515).

🤖 Generated with [Claude Code](https://claude.com/claude-code)