### PR TITLE
fix: pin Node to 22.22.0 in all callers of danger workflow

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: 'Node.js version to use'
     required: false
-    default: '22'
+    default: '22.22.0'
   install-from-caller:
     description: 'Whether to install from caller directory or tooling directory'
     required: false

--- a/.github/workflows/add-version-label.yml
+++ b/.github/workflows/add-version-label.yml
@@ -7,7 +7,7 @@ on:
         required: true
     inputs:
       node-version:
-        default: "22"
+        default: "22.22.0"
         required: false
         type: string
 

--- a/.github/workflows/danger-yarn.yml
+++ b/.github/workflows/danger-yarn.yml
@@ -7,7 +7,7 @@ on:
         required: true
     inputs:
       node-version:
-        default: "22"
+        default: "22.22.0"
         required: false
         type: string
 


### PR DESCRIPTION
## Summary

Follows up on #85 — the previous PR only updated `danger.yml`'s default, but `danger-yarn.yml` and `add-version-label.yml` both pass `node-version` explicitly from their own defaults (`"22"`), which overrides `danger.yml`'s default. Also updated the `setup-and-install` composite action default.

## Chain

`run-danger-yarn.yml` → `danger-yarn.yml` (default: `"22.22.0"`) → `danger.yml` (default: `"22.22.0"`) → `setup-and-install` (default: `"22.22.0"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)