### PR TITLE
fix: remove Node 22.22.0 pin, float back to 22

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: 'Node.js version to use'
     required: false
-    default: '22.22.0'
+    default: '22'
   install-from-caller:
     description: 'Whether to install from caller directory or tooling directory'
     required: false

--- a/.github/workflows/add-version-label.yml
+++ b/.github/workflows/add-version-label.yml
@@ -7,7 +7,7 @@ on:
         required: true
     inputs:
       node-version:
-        default: "22.22.0"
+        default: "22"
         required: false
         type: string
 

--- a/.github/workflows/danger-yarn.yml
+++ b/.github/workflows/danger-yarn.yml
@@ -7,7 +7,7 @@ on:
         required: true
     inputs:
       node-version:
-        default: "22.22.0"
+        default: "22"
         required: false
         type: string
 

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,7 +11,7 @@ on:
         required: false
         type: string
       node-version:
-        default: "22.22.0"
+        default: "22"
         required: false
         type: string
       install-from-caller:


### PR DESCRIPTION
## Summary

Removes the `22.22.0` pin added in PRs #85 and #86. Node `22.23.1` includes the upstream fix ([nodejs/node#64004](https://github.com/nodejs/node/pull/64004)) that resolves the `ERR_STREAM_PREMATURE_CLOSE` regression introduced in `22.23.0`. The Node version cache will be manually cleared to ensure runners pick up `22.23.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)