### PR TITLE
fix: add check-latest: true to setup-node to bypass toolcache

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -16,6 +16,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
+        check-latest: true
         cache: yarn
         cache-dependency-path: |
           yarn.lock


### PR DESCRIPTION
## Summary

Adds `check-latest: true` to the `actions/setup-node` step in the composite action.

## Why

The GitHub-hosted runner's pre-installed toolcache contains Node `22.23.0`, which introduced a regression in `node-fetch@2` causing `ERR_STREAM_PREMATURE_CLOSE`. Node `22.23.1` has the fix, but specifying `"22"` always resolves to the toolcache version (`22.23.0`). `check-latest: true` forces `actions/setup-node` to check for the latest matching version and download `22.23.1` instead.

Tracking issue: [danger/danger-js#1515](https://github.com/danger/danger-js/issues/1515)

🤖 Generated with [Claude Code](https://claude.com/claude-code)