### PR TITLE
feat: add reusable lint-agents-md workflow

### DIFF
--- a/.github/workflows/lint-agents-md.yml
+++ b/.github/workflows/lint-agents-md.yml
@@ -1,0 +1,38 @@
+name: Lint AGENTS.md
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Check AGENTS.md is tool-agnostic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail on Claude-specific patterns in AGENTS.md
+        run: |
+          PATTERNS=(
+            'mcp__claude_ai_'
+            'mcp__claude_'
+            '\bClaude will\b'
+            '\bClaude should\b'
+            "Claude's "
+            '/plugin marketplace'
+            '/plugin install'
+            'claude --plugin-dir'
+            'claude plugin validate'
+            '\${CLAUDE_PLUGIN_ROOT}'
+            'PreToolUse'
+          )
+          failed=0
+          for pattern in "${PATTERNS[@]}"; do
+            if grep -Pn "$pattern" AGENTS.md; then
+              echo "::error file=AGENTS.md::Found Claude-specific pattern: $pattern"
+              echo "  → Move this content to CLAUDE.md instead."
+              failed=1
+            fi
+          done
+          if [ "$failed" -eq 1 ]; then
+            exit 1
+          fi
+          echo "AGENTS.md is clean — no Claude-specific patterns found."

--- a/.github/workflows/lint-agents-md.yml
+++ b/.github/workflows/lint-agents-md.yml
@@ -32,7 +32,5 @@ jobs:
               failed=1
             fi
           done
-          if [ "$failed" -eq 1 ]; then
-            exit 1
-          fi
+          if [ "$failed" -eq 1 ]; then exit 1; fi
           echo "AGENTS.md is clean — no Claude-specific patterns found."


### PR DESCRIPTION
In this PR, I am adding a reusable workflow that checks `AGENTS.md` for Claude Code-specific patterns that belong in `CLAUDE.md` instead. Any Artsy repo can adopt it with one line: `uses: artsy/duchamp/.github/workflows/lint-agents-md.yml@main`. First consumer: `artsy/agent-tooling` PR [#15](https://github.com/artsy/agent-tooling/pull/15).