### PR TITLE
feat: add sync-agent-wrappers script and composite action

### DIFF
--- a/.github/actions/sync-agent-wrappers/action.yml
+++ b/.github/actions/sync-agent-wrappers/action.yml
@@ -1,0 +1,11 @@
+name: Sync agent wrappers
+description: Generates .cursorrules and .github/copilot-instructions.md from AGENTS.md. Add new agent formats in scripts/sync-agent-wrappers.sh to propagate to all consuming repos.
+
+runs:
+  using: composite
+  steps:
+    - name: Generate wrapper files
+      shell: bash
+      run: |
+        curl -sS https://raw.githubusercontent.com/artsy/duchamp/main/scripts/sync-agent-wrappers.sh | \
+          REPO_ROOT="$GITHUB_WORKSPACE" bash

--- a/scripts/sync-agent-wrappers.sh
+++ b/scripts/sync-agent-wrappers.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Generates agent wrapper files from AGENTS.md in the current repo.
+# This is the source of truth — update here to add/remove agent support.
+# Called by .github/actions/sync-agent-wrappers in CI; run locally for dev.
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+AGENTS_MD="$REPO_ROOT/AGENTS.md"
+HEADER="<!-- Auto-generated from AGENTS.md — do not edit directly. Run: curl -sS https://raw.githubusercontent.com/artsy/duchamp/main/scripts/sync-agent-wrappers.sh | bash -->"
+
+generate() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")"
+  { printf '%s\n\n' "$HEADER"; cat "$AGENTS_MD"; } > "$dest"
+  echo "  wrote $dest"
+}
+
+echo "Syncing agent wrappers from AGENTS.md..."
+generate "$REPO_ROOT/.cursorrules"
+generate "$REPO_ROOT/.github/copilot-instructions.md"
+echo "Done."


### PR DESCRIPTION
In this PR, I am adding `scripts/sync-agent-wrappers.sh` as the single source of truth for which agent wrapper files Artsy repos generate from `AGENTS.md`. The composite action runs the script in CI so consuming repos call it with `uses: artsy/duchamp/.github/actions/sync-agent-wrappers@main`. To add a new agent format, update the script here — all repos pick it up automatically. First consumer: `artsy/agent-tooling` PR [#15](https://github.com/artsy/agent-tooling/pull/15).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYAoVcr13ruwsWDe2ou236)_