### PR TITLE
feat: add reusable auto-sync-agent-wrappers workflow

### DIFF
--- a/.github/workflows/sync-agent-wrappers.yml
+++ b/.github/workflows/sync-agent-wrappers.yml
@@ -1,0 +1,34 @@
+name: Sync agent wrappers
+
+# Reusable workflow. A consuming repo calls this on push (usually filtered
+# to AGENTS.md) and it regenerates the agent wrapper files from AGENTS.md
+# and commits them back to the pushed branch. The caller must grant
+# `contents: write` so the commit can be pushed.
+on:
+  workflow_call:
+
+jobs:
+  sync:
+    name: Sync agent wrappers from AGENTS.md
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate wrapper files
+        uses: artsy/duchamp/.github/actions/sync-agent-wrappers@main
+
+      - name: Commit regenerated wrappers
+        run: |
+          set -euo pipefail
+          if git diff --quiet .cursorrules .github/copilot-instructions.md; then
+            echo "Agent wrappers already in sync — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .cursorrules .github/copilot-instructions.md
+          git commit -m "chore: sync agent wrappers from AGENTS.md"
+          git push
+          echo "Regenerated agent wrappers committed."


### PR DESCRIPTION
In this PR, I am adding a reusable workflow that **auto-commits** regenerated agent wrapper files (`.cursorrules`, `.github/copilot-instructions.md`) whenever `AGENTS.md` changes. It complements the existing `sync-agent-wrappers` composite action (which only generates) and the `lint-agents-md` guard (which only detects drift): this one regenerates and pushes the wrappers back to the branch, so editing `AGENTS.md` automatically keeps the wrappers in sync.

Consuming repos call it on push with `contents: write`:

```yaml
name: Sync agent wrappers
on:
  push:
    paths:
      - AGENTS.md
jobs:
  sync:
    permissions:
      contents: write
    uses: artsy/duchamp/.github/workflows/sync-agent-wrappers.yml@main
```

The bot commit only touches the generated wrappers (not `AGENTS.md`), so the `paths` filter prevents any re-trigger loop. First consumer: `artsy/agent-tooling`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYAoVcr13ruwsWDe2ou236)_