### PR TITLE
fix: check out with sync-token so git push uses the PAT

### DIFF
--- a/.github/workflows/open-agent-wrappers-pr.yml
+++ b/.github/workflows/open-agent-wrappers-pr.yml
@@ -21,7 +21,15 @@ jobs:
     name: Open agent wrappers sync PR
     runs-on: ubuntu-latest
     steps:
+      # Check out with the sync-token so its credentials are the ones
+      # persisted into git config (as http.extraheader). Otherwise
+      # actions/checkout persists the default GITHUB_TOKEN, whose header
+      # takes precedence over `gh auth setup-git` and would make the raw
+      # `git push` below authenticate as GITHUB_TOKEN — which does not
+      # trigger the opened PR's required checks, so auto-merge would hang.
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.sync-token }}
 
       - name: Generate wrapper files
         uses: artsy/duchamp/.github/actions/sync-agent-wrappers@main
@@ -41,12 +49,10 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # gh auth only covers gh's own calls; setup-git lets raw git
-          # (push) authenticate with the same token.
-          gh auth setup-git
 
           # Rebuild the sync branch fresh from the pushed commit and
-          # force-push, so it never accumulates stale history.
+          # force-push, so it never accumulates stale history. The push
+          # authenticates with the sync-token persisted at checkout.
           git checkout -b "$BRANCH"
           git add .cursorrules .github/copilot-instructions.md
           git commit -m "chore: sync agent wrappers from AGENTS.md"


### PR DESCRIPTION
Fixes a real bug in the `open-agent-wrappers-pr` reusable workflow flagged in review ([#93 discussion](https://github.com/artsy/duchamp/pull/93#discussion_r3535043141)).

**Problem:** `actions/checkout@v4` defaults to `persist-credentials: true`, which writes the default `GITHUB_TOKEN` into git config as an `http.https://github.com/.extraheader` `AUTHORIZATION` header. That header is sent on every github.com git operation and takes precedence over the credential helper `gh auth setup-git` installs — so the raw `git push` authenticated as `GITHUB_TOKEN`, not `sync-token`. A push made with `GITHUB_TOKEN` doesn't trigger the opened PR's required checks (and, without an explicit `contents: write`, could 403 outright), defeating the auto-merge design.

**Fix:** pass `token: ${{ secrets.sync-token }}` to `actions/checkout`, so the persisted credentials are the PAT's and every git operation — including the push — authenticates correctly. Also removed the now-redundant `gh auth setup-git` step.

No `permissions:` block is needed: every git and `gh` operation now uses `sync-token`, so the job's `GITHUB_TOKEN` scope is irrelevant.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYAoVcr13ruwsWDe2ou236)_