### PR TITLE
fix: only run wrapper hand-edit guard on PRs into the default branch

### DIFF
--- a/.github/workflows/lint-agents-md.yml
+++ b/.github/workflows/lint-agents-md.yml
@@ -37,7 +37,12 @@ jobs:
 
   wrappers:
     name: Check agent wrappers are not hand-edited
-    if: github.event_name == 'pull_request'
+    # Only guard PRs into the default branch. Deploy/release PRs (e.g.
+    # staging → release) legitimately carry already-merged wrapper commits
+    # forward and must not be flagged as hand-edits.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
       - name: Reject manual edits to generated wrapper files


### PR DESCRIPTION
The `Check agent wrappers are not hand-edited` guard was failing on **deploy/release PRs** (e.g. force's `staging → release` "Deploy" PR). Those PRs carry already-merged wrapper commits forward, so the guard saw wrapper files in the diff and flagged them as hand-edits — a false positive on every deploy.

Fix: gate the `wrappers` job on `github.event.pull_request.base.ref == github.event.repository.default_branch`, so it only runs for PRs into the default branch (`main`). Deploy PRs into `release`/`staging` skip it entirely. The tool-agnostic lint job is unchanged.

Applies to all consumers of the reusable workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYAoVcr13ruwsWDe2ou236)_