### PR TITLE
fix: detect newly-created wrapper files on first-time bootstrap

### DIFF
--- a/.github/workflows/open-agent-wrappers-pr.yml
+++ b/.github/workflows/open-agent-wrappers-pr.yml
@@ -39,7 +39,13 @@ jobs:
           GH_TOKEN: ${{ secrets.sync-token }}
         run: |
           set -euo pipefail
-          if git diff --quiet .cursorrules .github/copilot-instructions.md; then
+          # Use `git status --porcelain` rather than `git diff`: on a repo's
+          # first-time bootstrap the wrapper files don't exist yet, so the
+          # freshly-generated ones are untracked — `git diff` (working tree
+          # vs index) ignores untracked files and would report "no change",
+          # skipping the PR. `git status --porcelain` reports untracked files
+          # (as `??`) as well as modifications.
+          if [ -z "$(git status --porcelain -- .cursorrules .github/copilot-instructions.md)" ]; then
             echo "Wrappers already in sync with AGENTS.md — nothing to do."
             exit 0
           fi


### PR DESCRIPTION
The sync workflow skipped opening a PR on a repo's **first-time bootstrap** (observed on `artsy/volt`: the workflow ran, logged "Wrappers already in sync — nothing to do", and opened no PR).

Cause: the drift check used `git diff --quiet`, which only compares **tracked** files. When a repo has no wrapper files yet, the freshly-generated `.cursorrules` / `.github/copilot-instructions.md` are **untracked**, so `git diff` reports no change and the script exits early.

Fix: use `git status --porcelain -- <wrappers>`, which reports untracked files (`??`) as well as modifications. Repos that already have wrappers (force, agent-tooling) were unaffected; this specifically fixes bootstrapping a new repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYAoVcr13ruwsWDe2ou236)_