### PR TITLE
feat: AI-generated deploy Slack notifications

### DIFF
--- a/.github/workflows/deploy-notification.yml
+++ b/.github/workflows/deploy-notification.yml
@@ -1,0 +1,65 @@
+name: Deploy Slack Notification
+
+on:
+  workflow_call:
+    secrets:
+      anthropic-api-key:
+        required: true
+      slack-bot-token:
+        required: true
+    inputs:
+      release-branch:
+        description: "Base branch that deploy PRs merge into"
+        default: "release"
+        required: false
+        type: string
+      model:
+        description: "Claude model used to write the digest"
+        default: "claude-opus-4-8"
+        required: false
+        type: string
+
+jobs:
+  notify:
+    # Only run for merged deploy PRs into the release branch
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == inputs.release-branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout tooling repo
+        uses: actions/checkout@v4
+        with:
+          repository: artsy/duchamp
+          ref: main
+          path: .tooling
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install tooling dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: .tooling
+        env:
+          YARN_IGNORE_PATH: 1
+
+      - name: Generate and post deploy digest
+        run: npx ts-node .tooling/scripts/deploy-notification.ts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DEPLOY_PR_NUMBER: ${{ github.event.pull_request.number }}
+          DEPLOY_PR_URL: ${{ github.event.pull_request.html_url }}
+          ANTHROPIC_API_KEY: ${{ secrets.anthropic-api-key }}
+          SLACK_BOT_TOKEN: ${{ secrets.slack-bot-token }}
+          CLAUDE_MODEL: ${{ inputs.model }}
+          CONFIG_PATH: .tooling/deploy-notifications.yml

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Duchamp provides shared GitHub Actions and Danger.js configurations that help en
 - **Standardized CI/CD workflows** for Node.js projects
 - **Conventional commits** validation
 - **AGENTS.md tooling** — lint and auto-sync agent instruction files across repos
+- **Deploy Slack notifications** — AI-generated digests posted to subscribed Slack channels when a Deploy PR merges
 
 ## 🚀 Quick Start
 
@@ -43,6 +44,7 @@ For detailed documentation, see the [docs/](./docs/) directory:
 - [Available Actions](./docs/actions.md) - Detailed action reference
 - [Examples](./docs/examples.md) - Real-world usage examples
 - [Adopting AGENTS.md tooling](./docs/adopting-agents-md.md) - Add AGENTS.md lint + wrapper auto-sync to a repo
+- [Deploy Slack Notifications](./docs/deploy-notifications.md) - AI-generated deploy digests for Slack channels
 
 ## 🛠 Development
 

--- a/deploy-notifications.yml
+++ b/deploy-notifications.yml
@@ -1,0 +1,25 @@
+# Deploy Slack notification subscriptions
+#
+# Slack channels can subscribe to Artsy repos here to get an AI-generated
+# digest whenever a Deploy PR is merged in that repo.
+#
+# To subscribe a channel, open a PR against this file. The Slack bot must be
+# invited to the channel (`/invite @<bot-name>`) for posting to work.
+#
+# Per repo:
+#   channels: List of Slack channel names to notify.
+#   context:  Optional free-text hints for Claude when writing the digest
+#             (domain glossary, how to group things, naming conventions, ...).
+#
+# See docs/deploy-notifications.md for full setup instructions.
+
+subscriptions:
+  artsy/volt:
+    channels:
+      - "#product-amber"
+    context: |
+      Volt is Artsy's CMS for gallery partners (also called Artsy CMS).
+      ArtOS is the partner CMS experience within Volt: catalog, lists,
+      settings, and the Instagram/Mailchimp/Tearsheet/Checklist Studio
+      editors. Prefix changes touching those areas with "ArtOS:" even if
+      the PR title doesn't literally say "ArtOS".

--- a/docs/deploy-notifications.md
+++ b/docs/deploy-notifications.md
@@ -1,0 +1,89 @@
+# Deploy Slack Notifications
+
+AI-generated "New changes just went live! 🥳" digests, posted to Slack when a Deploy PR is merged.
+
+Slack channels subscribe to Artsy repos in a central config. When a Deploy PR merges in a subscribed repo, a GitHub Action collects the shipped PRs, asks Claude to write a plain-language digest, and posts it to the subscribed channels:
+
+- **Top-level message**: link to the deploy PR, plus any genuinely new user-facing features. If there are none: "No new features this time — check the thread for fixes and improvements 🧵".
+- **Thread reply**: everything else (bug fixes, chores, dependency bumps, test/tooling work), split into **Fixes** and **Improvements & Maintenance**.
+
+Each item gets a short plain-language title, a one-sentence description a non-engineer can understand, and links to the PR (plus its Jira/Notion ticket if the PR body mentions one).
+
+## How it works
+
+1. A repo (e.g. `artsy/volt`) has a small workflow that calls duchamp's reusable [`deploy-notification.yml`](../.github/workflows/deploy-notification.yml) whenever a PR is closed.
+2. The reusable workflow only proceeds when the PR was **merged** and its **base branch is the release branch** (default: `release`) — that's what identifies a Deploy PR.
+3. [`scripts/deploy-notification.ts`](../scripts/deploy-notification.ts) then:
+   - looks up the repo in [`deploy-notifications.yml`](../deploy-notifications.yml) (exits quietly if no channel is subscribed),
+   - lists the commits contained in the deploy PR and extracts the shipped PR numbers (squash merges and merge commits),
+   - fetches each shipped PR's title and description from the GitHub API,
+   - sends everything to the Claude API, which returns the two Slack messages as JSON,
+   - posts the top-level message and the thread reply to every subscribed channel via `chat.postMessage`.
+
+## Subscribing a channel to a repo
+
+Open a PR against [`deploy-notifications.yml`](../deploy-notifications.yml) in this repo:
+
+```yaml
+subscriptions:
+  artsy/<repo>:
+    channels:
+      - "#your-channel"
+    # Optional: domain hints that make the digest better
+    context: |
+      <Glossary, product-area names, grouping hints for Claude.>
+```
+
+Then invite the Slack bot to the channel: `/invite @<bot-name>`.
+
+If the repo isn't emitting notifications yet, also do the one-time repo setup below.
+
+## One-time setup per repo
+
+1. Copy [`templates/run-deploy-notification.yml`](../templates/run-deploy-notification.yml) to `.github/workflows/deploy-notification.yml` in the repo.
+2. If deploy PRs merge into a branch other than `release`, set the `release-branch` input.
+3. Make sure the repo has access to the `ANTHROPIC_API_KEY` and `SLACK_BOT_TOKEN` secrets (see below).
+
+## One-time org setup (what else is needed)
+
+These things exist outside this repo and must be set up once:
+
+1. **Slack app / bot**
+   - Create a Slack app in the Artsy workspace (or reuse an existing bot).
+   - Add the `chat:write` bot scope and install the app to the workspace.
+   - Invite the bot to every subscribed channel.
+2. **Secrets** (GitHub org-level secrets recommended, so every repo can use them):
+   - `ANTHROPIC_API_KEY` — Claude API key (already used by the AI PR review workflow).
+   - `SLACK_BOT_TOKEN` — the Slack app's bot token (`xoxb-...`).
+
+## Configuration reference
+
+`deploy-notifications.yml` (in duchamp):
+
+| Key | Description |
+| --- | --- |
+| `subscriptions.<owner/repo>.channels` | Slack channels to notify (bot must be a member). |
+| `subscriptions.<owner/repo>.context` | Optional free-text hints for Claude (glossary, product areas, grouping rules). |
+
+Reusable workflow inputs (set in the calling repo's workflow):
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `release-branch` | `release` | Base branch that identifies a Deploy PR. |
+| `model` | `claude-opus-4-8` | Claude model used to write the digest. |
+
+## Testing locally
+
+Preview the Claude prompt for a real deploy PR without any API keys (uses your `gh` CLI auth; nothing is sent to Claude or Slack):
+
+```bash
+npx ts-node scripts/test-deploy-notification.ts artsy/volt 11796
+```
+
+Status output goes to stderr, the prompt to stdout, so you can pipe it — e.g. `| pbcopy` and paste into Claude to preview the digest.
+
+## Limitations
+
+- Shipped PRs are detected from commit messages in the deploy PR (squash merges `(#123)` and merge commits `Merge pull request #123`). Direct commits without a PR reference are not summarized.
+- Digests cover at most 50 shipped PRs per deploy.
+- Channels are looked up against duchamp's `main` branch at run time, so subscription changes take effect on the next deploy without touching the consumer repo.

--- a/scripts/deploy-notification.test.ts
+++ b/scripts/deploy-notification.test.ts
@@ -1,0 +1,94 @@
+import {
+  buildPrompt,
+  extractPrNumbers,
+  parseDigest,
+} from "./deploy-notification"
+
+describe("extractPrNumbers", () => {
+  it("extracts numbers from squash-merge commit subjects", () => {
+    expect(
+      extractPrNumbers([
+        "fix: correct dimension unit switching (#11800)",
+        "chore(deps): bump aws-sdk-s3 (#11795)",
+      ])
+    ).toEqual([11795, 11800])
+  })
+
+  it("extracts numbers from merge commits", () => {
+    expect(
+      extractPrNumbers([
+        "Merge pull request #11786 from artsy/feature-branch\n\nStudio links",
+      ])
+    ).toEqual([11786])
+  })
+
+  it("ignores issue references in commit bodies and mid-subject", () => {
+    expect(
+      extractPrNumbers([
+        "fix: something\n\nCloses #99",
+        "revert #123 behavior for safety",
+      ])
+    ).toEqual([])
+  })
+
+  it("deduplicates and sorts", () => {
+    expect(extractPrNumbers(["a (#5)", "b (#3)", "c (#5)"])).toEqual([3, 5])
+  })
+})
+
+describe("parseDigest", () => {
+  it("parses plain JSON", () => {
+    expect(
+      parseDigest('{"top_message": "hi", "thread_message": "there"}')
+    ).toEqual({
+      top_message: "hi",
+      thread_message: "there",
+    })
+  })
+
+  it("parses JSON wrapped in code fences", () => {
+    expect(
+      parseDigest('```json\n{"top_message": "hi", "thread_message": null}\n```')
+    ).toEqual({
+      top_message: "hi",
+      thread_message: null,
+    })
+  })
+
+  it("throws when top_message is missing", () => {
+    expect(() => parseDigest('{"thread_message": "x"}')).toThrow(
+      "missing top_message"
+    )
+  })
+})
+
+describe("buildPrompt", () => {
+  it("includes repo context, deploy PR url, and shipped PRs", () => {
+    const prompt = buildPrompt({
+      repo: "artsy/volt",
+      deployPrUrl: "https://github.com/artsy/volt/pull/11796",
+      repoContext: "ArtOS is the partner CMS.",
+      shippedPrs: [
+        {
+          number: 11800,
+          title: "fix: dimension units",
+          body: "Fixes AMBER-2021",
+          url: "https://github.com/artsy/volt/pull/11800",
+          author: "ole",
+        },
+      ],
+    })
+    expect(prompt).toContain("ArtOS is the partner CMS.")
+    expect(prompt).toContain("https://github.com/artsy/volt/pull/11796")
+    expect(prompt).toContain("PR #11800: fix: dimension units")
+  })
+
+  it("omits the context section when no context is configured", () => {
+    const prompt = buildPrompt({
+      repo: "artsy/volt",
+      deployPrUrl: "https://github.com/artsy/volt/pull/1",
+      shippedPrs: [],
+    })
+    expect(prompt).not.toContain("## Repository context")
+  })
+})

--- a/scripts/deploy-notification.ts
+++ b/scripts/deploy-notification.ts
@@ -1,0 +1,308 @@
+import * as fs from "fs"
+import * as yaml from "js-yaml"
+
+/**
+ * Post an AI-generated deploy digest to Slack when a Deploy PR is merged.
+ *
+ * Reads channel subscriptions from deploy-notifications.yml (in duchamp),
+ * collects the PRs shipped in the deploy PR via the GitHub API, asks Claude
+ * to write a Slack digest (features in the top-level message, everything
+ * else in a thread reply), and posts it via the Slack API.
+ *
+ * Required env vars:
+ *   GITHUB_REPOSITORY   e.g. "artsy/volt"
+ *   DEPLOY_PR_NUMBER    number of the merged deploy PR
+ *   DEPLOY_PR_URL       html url of the deploy PR
+ *   GITHUB_TOKEN        token with read access to the repo's PRs
+ *   ANTHROPIC_API_KEY   Claude API key
+ *   SLACK_BOT_TOKEN     Slack bot token with chat:write
+ * Optional:
+ *   CONFIG_PATH         path to deploy-notifications.yml (default: ./deploy-notifications.yml)
+ *   CLAUDE_MODEL        model id (default: claude-opus-4-8)
+ */
+
+interface RepoSubscription {
+  channels: string[]
+  context?: string
+}
+
+interface Config {
+  subscriptions?: Record<string, RepoSubscription>
+}
+
+export interface ShippedPr {
+  number: number
+  title: string
+  body: string
+  url: string
+  author: string
+}
+
+export interface DigestMessages {
+  top_message: string
+  thread_message: string | null
+}
+
+/**
+ * Extract PR numbers referenced by the commits contained in a deploy PR.
+ * Handles squash merges ("Some change (#123)") and merge commits
+ * ("Merge pull request #123 from ...").
+ */
+export const extractPrNumbers = (commitMessages: string[]): number[] => {
+  const numbers = new Set<number>()
+  for (const message of commitMessages) {
+    const subject = message.split("\n")[0]
+    const mergeMatch = subject.match(/^Merge pull request #(\d+)/)
+    if (mergeMatch) {
+      numbers.add(Number(mergeMatch[1]))
+      continue
+    }
+    const squashMatch = subject.match(/\(#(\d+)\)\s*$/)
+    if (squashMatch) {
+      numbers.add(Number(squashMatch[1]))
+    }
+  }
+  return [...numbers].sort((a, b) => a - b)
+}
+
+/**
+ * Parse Claude's response into the two Slack messages. Tolerates markdown
+ * code fences around the JSON.
+ */
+export const parseDigest = (text: string): DigestMessages => {
+  const stripped = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/```\s*$/, "")
+  const parsed = JSON.parse(stripped)
+  if (typeof parsed.top_message !== "string" || parsed.top_message === "") {
+    throw new Error("Claude response is missing top_message")
+  }
+  return {
+    top_message: parsed.top_message,
+    thread_message:
+      typeof parsed.thread_message === "string" && parsed.thread_message !== ""
+        ? parsed.thread_message
+        : null,
+  }
+}
+
+export const buildPrompt = (options: {
+  repo: string
+  deployPrUrl: string
+  repoContext?: string
+  shippedPrs: ShippedPr[]
+}): string => {
+  const prList = options.shippedPrs
+    .map(
+      pr =>
+        `### PR #${pr.number}: ${pr.title}\nURL: ${pr.url}\nAuthor: ${pr.author}\nBody:\n${pr.body || "(no description)"}`
+    )
+    .join("\n\n")
+
+  return `You are writing a Slack deploy notification for the repository ${options.repo}.
+A Deploy PR just merged (${options.deployPrUrl}), shipping the pull requests listed below.
+
+${options.repoContext ? `## Repository context\n${options.repoContext}\n` : ""}
+## Task
+Write two Slack messages:
+
+1. **top_message** — starts with "🚀 A new batch of ${options.repo.split("/")[1]} changes just went live (<${options.deployPrUrl}|PR>)!". If any shipped PRs are genuinely new user-facing features, list them here under a "*New Features*" heading and end with "Check the thread for fixes and improvements 🧵". If there are no new features, instead end with "No new features this time — check the thread for fixes and improvements 🧵" (and no feature list). If there is nothing at all for the thread either, end with no thread reference.
+
+2. **thread_message** — everything that is not a new user-facing feature (bug fixes, chores, dependency bumps, test/tooling work), split into a "*Fixes*" group and an "*Improvements & Maintenance*" group. Omit an empty group. If nothing belongs in the thread, use null.
+
+For each item:
+- Give it a short plain-language title in bold, prefixed with the product area it touches, then an em dash and a one-sentence description a non-engineer can understand.
+- Link the PR, plus its Jira/Notion ticket and feature flag if the PR body mentions one.
+- Example item: "• *Artworks: Correct Dimension Unit Switching* — switching units now immediately shows converted values instead of stale ones (<https://github.com/artsy/volt/pull/11800|PR> · <https://artsyproduct.atlassian.net/browse/AMBER-2021|Jira>)"
+
+Formatting rules:
+- Use Slack mrkdwn, NOT standard markdown: *bold*, <url|text> links, "•" for bullets.
+- Be accurate: only call something a new feature if the PR clearly introduces new user-facing functionality.
+- Keep descriptions honest and plain; routine dependency updates get "routine dependency update ... with no visible changes".
+
+## Shipped pull requests
+${prList}
+
+## Output
+Respond with ONLY a JSON object, no other text:
+{"top_message": "...", "thread_message": "..." or null}`
+}
+
+const githubFetch = async (path: string, token: string): Promise<any> => {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+    },
+  })
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API ${path} failed: ${response.status} ${await response.text()}`
+    )
+  }
+  return response.json()
+}
+
+export const fetchShippedPrs = async (
+  repo: string,
+  deployPrNumber: number,
+  token: string
+): Promise<ShippedPr[]> => {
+  const messages: string[] = []
+  for (let page = 1; page <= 3; page++) {
+    const commits = await githubFetch(
+      `/repos/${repo}/pulls/${deployPrNumber}/commits?per_page=100&page=${page}`,
+      token
+    )
+    messages.push(...commits.map((c: any) => c.commit.message))
+    if (commits.length < 100) break
+  }
+
+  const numbers = extractPrNumbers(messages).filter(n => n !== deployPrNumber)
+  const limited = numbers.slice(0, 50)
+  if (numbers.length > limited.length) {
+    console.warn(
+      `Deploy contains ${numbers.length} PRs; summarizing the first ${limited.length}.`
+    )
+  }
+
+  const prs: ShippedPr[] = []
+  for (const number of limited) {
+    try {
+      const pr = await githubFetch(`/repos/${repo}/pulls/${number}`, token)
+      prs.push({
+        number,
+        title: pr.title,
+        body: (pr.body || "").slice(0, 1500),
+        url: pr.html_url,
+        author: pr.user?.login || "unknown",
+      })
+    } catch (error) {
+      console.warn(`Skipping PR #${number}: ${error}`)
+    }
+  }
+  return prs
+}
+
+const askClaude = async (
+  prompt: string,
+  apiKey: string,
+  model: string
+): Promise<DigestMessages> => {
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 4000,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  })
+  if (!response.ok) {
+    throw new Error(
+      `Claude API failed: ${response.status} ${await response.text()}`
+    )
+  }
+  const data = await response.json()
+  const text = data.content
+    .filter((block: any) => block.type === "text")
+    .map((block: any) => block.text)
+    .join("")
+  return parseDigest(text)
+}
+
+const postToSlack = async (
+  channel: string,
+  digest: DigestMessages,
+  token: string
+): Promise<void> => {
+  const post = async (text: string, threadTs?: string): Promise<string> => {
+    const response = await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        channel,
+        text,
+        unfurl_links: false,
+        unfurl_media: false,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+      }),
+    })
+    const data = await response.json()
+    if (!data.ok) {
+      throw new Error(
+        `Slack chat.postMessage to ${channel} failed: ${data.error}`
+      )
+    }
+    return data.ts
+  }
+
+  const ts = await post(digest.top_message)
+  if (digest.thread_message) {
+    await post(digest.thread_message, ts)
+  }
+  console.log(`Posted deploy notification to ${channel}`)
+}
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`)
+  }
+  return value
+}
+
+const main = async (): Promise<void> => {
+  const repo = requireEnv("GITHUB_REPOSITORY")
+  const deployPrNumber = Number(requireEnv("DEPLOY_PR_NUMBER"))
+  const deployPrUrl = requireEnv("DEPLOY_PR_URL")
+  const githubToken = requireEnv("GITHUB_TOKEN")
+  const configPath = process.env.CONFIG_PATH || "deploy-notifications.yml"
+  const model = process.env.CLAUDE_MODEL || "claude-opus-4-8"
+
+  const config = yaml.load(fs.readFileSync(configPath, "utf8")) as Config
+  const subscription = config.subscriptions?.[repo]
+  if (!subscription || subscription.channels.length === 0) {
+    console.log(`No Slack channels subscribed to ${repo}. Nothing to do.`)
+    return
+  }
+
+  const anthropicApiKey = requireEnv("ANTHROPIC_API_KEY")
+  const slackToken = requireEnv("SLACK_BOT_TOKEN")
+
+  const shippedPrs = await fetchShippedPrs(repo, deployPrNumber, githubToken)
+  if (shippedPrs.length === 0) {
+    console.log("No shipped PRs found in the deploy PR. Nothing to announce.")
+    return
+  }
+  console.log(
+    `Found ${shippedPrs.length} shipped PRs. Generating digest with ${model}...`
+  )
+
+  const prompt = buildPrompt({
+    repo,
+    deployPrUrl,
+    repoContext: subscription.context,
+    shippedPrs,
+  })
+  const digest = await askClaude(prompt, anthropicApiKey, model)
+
+  for (const channel of subscription.channels) {
+    await postToSlack(channel, digest, slackToken)
+  }
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/scripts/test-deploy-notification.ts
+++ b/scripts/test-deploy-notification.ts
@@ -1,0 +1,83 @@
+import { execSync } from "child_process"
+import * as fs from "fs"
+import * as yaml from "js-yaml"
+import { buildPrompt, fetchShippedPrs } from "./deploy-notification"
+
+/**
+ * Local dry-run for the deploy Slack notification: fetches the shipped PRs
+ * of a real deploy PR and prints the prompt that would be sent to Claude.
+ * Nothing is sent to the Claude or Slack APIs, so no API keys are needed.
+ *
+ * GitHub auth comes from the gh CLI (`gh auth login`), or optionally a
+ * GITHUB_TOKEN env var.
+ *
+ * Usage:
+ *   npx ts-node scripts/test-deploy-notification.ts <owner/repo> <deploy-pr-number>
+ *
+ * Example:
+ *   npx ts-node scripts/test-deploy-notification.ts artsy/volt 11796
+ */
+
+interface Config {
+  subscriptions?: Record<string, { channels: string[]; context?: string }>
+}
+
+const githubToken = (): string => {
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN
+  try {
+    return execSync("gh auth token", { encoding: "utf8" }).trim()
+  } catch {
+    console.error(
+      "No GitHub auth found. Run `gh auth login` or set GITHUB_TOKEN."
+    )
+    process.exit(1)
+  }
+}
+
+const main = async (): Promise<void> => {
+  const [repo, prArg] = process.argv.slice(2)
+  const deployPrNumber = Number(prArg)
+  if (!repo || !repo.includes("/") || !Number.isInteger(deployPrNumber)) {
+    console.error(
+      "Usage: npx ts-node scripts/test-deploy-notification.ts <owner/repo> <deploy-pr-number>"
+    )
+    process.exit(1)
+  }
+
+  const config = yaml.load(
+    fs.readFileSync(`${__dirname}/../deploy-notifications.yml`, "utf8")
+  ) as Config
+  const subscription = config.subscriptions?.[repo]
+  if (subscription) {
+    console.error(`Subscribed channels: ${subscription.channels.join(", ")}`)
+  } else {
+    console.error(
+      `Note: ${repo} is not in deploy-notifications.yml — using no repo context.`
+    )
+  }
+
+  console.error(`Fetching shipped PRs for ${repo}#${deployPrNumber}...`)
+  const shippedPrs = await fetchShippedPrs(repo, deployPrNumber, githubToken())
+  if (shippedPrs.length === 0) {
+    console.error("No shipped PRs found in this deploy PR.")
+    process.exit(1)
+  }
+  console.error(
+    `Found ${shippedPrs.length} shipped PRs: ${shippedPrs.map(pr => `#${pr.number}`).join(", ")}\n`
+  )
+
+  const prompt = buildPrompt({
+    repo,
+    deployPrUrl: `https://github.com/${repo}/pull/${deployPrNumber}`,
+    repoContext: subscription?.context,
+    shippedPrs,
+  })
+
+  // Prompt goes to stdout so it can be piped (status output goes to stderr)
+  console.log(prompt)
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/templates/run-deploy-notification.yml
+++ b/templates/run-deploy-notification.yml
@@ -1,0 +1,18 @@
+# Copy this file to .github/workflows/deploy-notification.yml in your repo.
+# Also add your repo + Slack channels to deploy-notifications.yml in artsy/duchamp.
+name: Deploy Slack Notification
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify:
+    uses: artsy/duchamp/.github/workflows/deploy-notification.yml@main
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+    # Optional: customize the release branch or model
+    # with:
+    #   release-branch: "release"
+    #   model: "claude-opus-4-8"


### PR DESCRIPTION
Resolves [“New changes just went live! 🥳” Deploy Slack notifications](https://app.notion.com/p/artsy/New-changes-just-went-live-Deploy-Slack-notifications-399cab0764a080d8937dd0537c9b2467)

## Description

Adds deploy Slack notifications: when a Deploy PR (merged into the release branch) ships in a subscribed repo, a GitHub Action collects the shipped PRs, asks Claude to write a plain-language digest, and posts it to the subscribed Slack channels — new features in the top-level message, fixes and maintenance in a thread reply. Channels subscribe to repos via a central `deploy-notifications.yml` config in duchamp.

## Example Slack Notification

<img width="944" height="473" alt="Bildschirmfoto 2026-07-16 um 13 22 16" src="https://github.com/user-attachments/assets/e606c6cf-f47f-4276-bea2-c6ba27be2c34" />


## Changes
- `deploy-notifications.yml` — central subscription config (repo → Slack channels + optional context hints for Claude), seeded with `artsy/volt` → `#product-amber`
- `.github/workflows/deploy-notification.yml` — reusable workflow, runs only for merged PRs into the release branch (default `release`)
- `scripts/deploy-notification.ts` — collects shipped PRs via the GitHub API, generates the digest via the Claude API, posts via Slack `chat.postMessage` (no new dependencies)
- `templates/run-deploy-notification.yml` — copy-paste caller workflow for consumer repos
- `scripts/test-deploy-notification.ts` — local dry-run that prints the Claude prompt for a real deploy PR, no API keys needed (uses `gh` auth)
- `docs/deploy-notifications.md` — setup docs incl. remaining org setup (Slack app with `chat:write`, `SLACK_BOT_TOKEN` org secret)
- Unit tests for PR-number extraction, response parsing, and prompt building



## Test Plan
- `yarn jest scripts/deploy-notification.test.ts` — 9 tests pass
- `npx ts-node scripts/test-deploy-notification.ts artsy/volt 11796` — verified against a real Volt deploy PR: shipped PRs detected, prompt rendered with repo context

Assisted-by: Claude:Fable-5 [claude-code]

🤖 Generated with [Claude Code](https://claude.com/claude-code)