### PR TITLE
feat: add incident.io standup reminder workflow

### DIFF
--- a/.github/workflows/incident-standup-reminder.yml
+++ b/.github/workflows/incident-standup-reminder.yml
@@ -1,0 +1,72 @@
+name: Incident.io Standup Reminder
+
+on:
+  workflow_call:
+    secrets:
+      incident-io-api-key:
+        required: true
+      slack-webhook-url:
+        required: true
+    inputs:
+      schedule-id:
+        description: "incident.io schedule ID for the Engineering on-call schedule"
+        required: true
+        type: string
+      node-version:
+        default: "22"
+        required: false
+        type: string
+      boundary-weekday:
+        description: "Day the on-call shift changes, 0 (Sun) - 6 (Sat). Default: 1 (Monday)"
+        default: 1
+        required: false
+        type: number
+      boundary-hour:
+        description: "Hour the on-call shift changes, 0-23, America/New_York time. Default: 11 (11am ET)"
+        default: 11
+        required: false
+        type: number
+
+jobs:
+  standup-reminder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout tooling repo
+        uses: actions/checkout@v4
+        with:
+          repository: artsy/duchamp
+          ref: main
+          path: .tooling
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install tooling dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: .tooling
+        env:
+          YARN_IGNORE_PATH: 1
+
+      - name: Run standup reminder
+        id: cli
+        run: .tooling/node_modules/.bin/ts-node .tooling/scripts/on-call/standup-reminder.ts
+        env:
+          INCIDENT_IO_API_KEY: ${{ secrets.incident-io-api-key }}
+          SCHEDULE_ID: ${{ inputs.schedule-id }}
+          STANDUP_BOUNDARY_WEEKDAY: ${{ inputs.boundary-weekday }}
+          STANDUP_BOUNDARY_HOUR: ${{ inputs.boundary-hour }}
+
+      - name: Standup Reminder > Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: ${{ steps.cli.outputs.payload }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -13,6 +13,7 @@ This document provides detailed reference information for all GitHub Actions ava
 | `run-npm-audit.yml`                  | Discover vulnerabilities       | For Node projects                   |
 | `run-claude-review.yml`              | AI-powered PR review           | For Claude-based code review        |
 | `link-pr-to-notion.yml`             | Link PRs to Notion tasks       | For repos using Notion task tracking |
+| `incident-standup-reminder.yml`      | Remind on-call to run standup  | For scheduled Slack standup reminders |
 
 ## Action Reference
 
@@ -367,6 +368,45 @@ The `NOTION_TOKEN` and `NOTION_ROOT_PAGE_ID` secrets must be configured before t
 
 ---
 
+### incident-standup-reminder.yml
+
+**Purpose**: Post a Slack reminder to the current on-call participant(s) to facilitate standup
+
+**Use Case**: Scheduled workflows that need to notify whoever is on-call right now, sourced from an incident.io schedule
+
+```yaml
+uses: artsy/duchamp/.github/workflows/incident-standup-reminder.yml@main
+with:
+  schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }} # incident.io schedule ID (required)
+  node-version: "22" # Node.js version (default: "22")
+  boundary-weekday: 1 # Day the on-call shift changes, 0 (Sun) - 6 (Sat) (default: 1, Monday)
+  boundary-hour: 11 # Hour the on-call shift changes, 0-23, America/New_York time (default: 11, 11am ET)
+secrets:
+  incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }} # Required
+  slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}     # Required
+```
+
+**Features:**
+
+- Queries incident.io's `/v2/schedule_entries` with a tight time window around "now" to find who is actually on call at the moment the workflow runs (incident.io has no dedicated "current on-call" endpoint, so the window is computed explicitly rather than relying on default query behavior)
+- Anchors that query to a deterministic on-call shift-change boundary (`boundary-weekday`/`boundary-hour`, in America/New_York time) rather than the workflow's literal execution time — since GitHub's `schedule` trigger can fire a few minutes late, this guarantees the reminder always reflects who was on-call up to the boundary, not whoever the schedule just handed off to, regardless of exactly when the job happens to run
+- Builds Slack mentions directly from each schedule entry's `slack_user_id` — no separate email-to-Slack-ID lookup step
+- Posts the reminder via `8398a7/action-slack@v3` using the caller's `SLACK_WEBHOOK_URL`
+
+**Inputs:**
+
+- `schedule-id` (required): incident.io schedule ID to query
+- `node-version` (optional): Node.js version to use
+- `boundary-weekday` (optional): Day of week the on-call shift changes, `0` (Sunday) through `6` (Saturday). Default: `1` (Monday). Must match the day this workflow actually runs on — a mismatch (e.g. the cron schedule changes but this isn't updated) causes the run to fail loudly rather than silently anchor to the wrong day
+- `boundary-hour` (optional): Hour of day the on-call shift changes, `0`-`23`, in America/New_York time. Default: `11` (11am ET)
+
+**Secrets:**
+
+- `incident-io-api-key` (required): incident.io API key with access to the schedule
+- `slack-webhook-url` (required): Slack incoming webhook URL to post the reminder to
+
+---
+
 ## Reusable Action
 
 ### setup-and-install
@@ -407,6 +447,7 @@ The `NOTION_TOKEN` and `NOTION_ROOT_PAGE_ID` secrets must be configured before t
 | Security vulnerability scanning | `run-npm-audit.yml`                  | Scans yarn.lock for vulnerabilities  |
 | AI-powered code review          | `run-claude-review.yml`              | Uses Claude to review PRs            |
 | Notion task tracking            | `link-pr-to-notion.yml`             | Links PRs to Notion tasks by short ID |
+| Scheduled on-call Slack reminders | `incident-standup-reminder.yml`   | Sources current on-call from incident.io |
 | Custom workflows                | `setup-and-install` action           | Use as a step in custom workflows    |
 
 ## Security Considerations

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -377,13 +377,13 @@ The `NOTION_TOKEN` and `NOTION_ROOT_PAGE_ID` secrets must be configured before t
 ```yaml
 uses: artsy/duchamp/.github/workflows/incident-standup-reminder.yml@main
 with:
-  schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }} # incident.io schedule ID (required)
-  node-version: "22" # Node.js version (default: "22")
-  boundary-weekday: 1 # Day the on-call shift changes, 0 (Sun) - 6 (Sat) (default: 1, Monday)
-  boundary-hour: 11 # Hour the on-call shift changes, 0-23, America/New_York time (default: 11, 11am ET)
+  schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
+  node-version: "22"
+  boundary-weekday: 1
+  boundary-hour: 11
 secrets:
-  incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }} # Required
-  slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}     # Required
+  incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
+  slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 
 **Features:**

--- a/scripts/on-call/incident-io.test.ts
+++ b/scripts/on-call/incident-io.test.ts
@@ -1,0 +1,167 @@
+import {
+  currentOnCallUsers,
+  fetchScheduleEntries,
+  type IncidentIoUser,
+  type ScheduleEntry,
+  scheduleUrl,
+  usersToMentions,
+} from "./incident-io"
+
+const jsonResponse = (body: unknown, ok = true, status = 200) => ({
+  ok,
+  status,
+  statusText: ok ? "OK" : "Error",
+  json: async () => body,
+})
+
+const user = (overrides: Partial<IncidentIoUser> = {}): IncidentIoUser => ({
+  id: "user-1",
+  name: "Alice",
+  email: "alice@artsy.net",
+  slack_user_id: "U_ALICE",
+  ...overrides,
+})
+
+const entry = (overrides: Partial<ScheduleEntry> = {}): ScheduleEntry => ({
+  entry_id: "entry-1",
+  fingerprint: "fingerprint-1",
+  start_at: "2026-07-15T14:00:00Z",
+  end_at: "2026-07-15T15:00:00Z",
+  user: user(),
+  ...overrides,
+})
+
+describe("fetchScheduleEntries", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest.fn()
+  })
+
+  it("requests the schedule_entries endpoint with schedule_id and an explicit window", async () => {
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        schedule_entries: { scheduled: [], overrides: [], final: [entry()] },
+      })
+    )
+
+    const start = new Date("2026-07-15T14:00:00Z")
+    const end = new Date("2026-07-15T14:01:00Z")
+    const result = await fetchScheduleEntries(
+      "test-api-key",
+      "schedule-123",
+      start,
+      end
+    )
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, options] = mockFetch.mock.calls[0]
+    const requestUrl = new URL(url)
+    expect(requestUrl.origin + requestUrl.pathname).toBe(
+      "https://api.incident.io/v2/schedule_entries"
+    )
+    expect(requestUrl.searchParams.get("schedule_id")).toBe("schedule-123")
+    expect(requestUrl.searchParams.get("entry_window_start")).toBe(
+      start.toISOString()
+    )
+    expect(requestUrl.searchParams.get("entry_window_end")).toBe(
+      end.toISOString()
+    )
+    expect(options.headers.Authorization).toBe("Bearer test-api-key")
+    expect(result).toEqual([entry()])
+  })
+
+  it("throws when the response is not ok", async () => {
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch.mockResolvedValue(jsonResponse({}, false, 401))
+
+    await expect(
+      fetchScheduleEntries("bad-key", "schedule-123", new Date(), new Date())
+    ).rejects.toThrow("incident.io schedule_entries request failed: 401")
+  })
+})
+
+describe("currentOnCallUsers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest.fn()
+  })
+
+  it("returns only entries whose window actually contains now", async () => {
+    const now = new Date("2026-07-15T14:30:00Z")
+    const active = entry({
+      start_at: "2026-07-15T14:00:00Z",
+      end_at: "2026-07-15T15:00:00Z",
+      user: user({ id: "active-user" }),
+    })
+    const notYetStarted = entry({
+      start_at: "2026-07-15T15:00:00Z",
+      end_at: "2026-07-15T16:00:00Z",
+      user: user({ id: "future-user" }),
+    })
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        schedule_entries: {
+          scheduled: [],
+          overrides: [],
+          final: [active, notYetStarted],
+        },
+      })
+    )
+
+    const result = await currentOnCallUsers("api-key", "schedule-123", now)
+
+    expect(result).toEqual([active.user])
+  })
+
+  it("dedupes users appearing in multiple concurrent entries", async () => {
+    const now = new Date("2026-07-15T14:30:00Z")
+    const sharedUser = user({ id: "shared-user" })
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        schedule_entries: {
+          scheduled: [],
+          overrides: [],
+          final: [
+            entry({ entry_id: "a", layer_id: "layer-1", user: sharedUser }),
+            entry({ entry_id: "b", layer_id: "layer-2", user: sharedUser }),
+          ],
+        },
+      })
+    )
+
+    const result = await currentOnCallUsers("api-key", "schedule-123", now)
+
+    expect(result).toEqual([sharedUser])
+  })
+})
+
+describe("scheduleUrl", () => {
+  it("builds the incident.io schedule URL from a schedule ID", () => {
+    expect(scheduleUrl("01K9G0DQWFHCVQTHZ3FAYEV2VH")).toBe(
+      "https://app.incident.io/artsy/on-call/schedules/01K9G0DQWFHCVQTHZ3FAYEV2VH"
+    )
+  })
+})
+
+describe("usersToMentions", () => {
+  it("maps users with a slack_user_id to Slack mention syntax", () => {
+    const result = usersToMentions([
+      user({ slack_user_id: "U_ALICE" }),
+      user({ id: "user-2", slack_user_id: "U_BOB" }),
+    ])
+
+    expect(result).toEqual(["<@U_ALICE>", "<@U_BOB>"])
+  })
+
+  it("skips users without a slack_user_id", () => {
+    const result = usersToMentions([
+      user({ slack_user_id: undefined }),
+      user({ id: "user-2", slack_user_id: "U_BOB" }),
+    ])
+
+    expect(result).toEqual(["<@U_BOB>"])
+  })
+})

--- a/scripts/on-call/incident-io.ts
+++ b/scripts/on-call/incident-io.ts
@@ -1,0 +1,96 @@
+const INCIDENT_IO_BASE_URL = "https://api.incident.io/v2"
+const INCIDENT_IO_APP_SCHEDULES_URL =
+  "https://app.incident.io/artsy/on-call/schedules"
+
+// A gap this small around "now" absorbs clock skew/request latency without
+// risking that the window drifts into the next shift.
+const CURRENT_SHIFT_WINDOW_PADDING_MS = 60_000
+
+export interface IncidentIoUser {
+  id: string
+  name: string
+  email: string
+  slack_user_id?: string
+}
+
+export interface ScheduleEntry {
+  entry_id: string
+  fingerprint: string
+  rotation_id?: string
+  layer_id?: string
+  start_at: string
+  end_at: string
+  user: IncidentIoUser
+}
+
+interface ScheduleEntriesResponse {
+  schedule_entries: {
+    scheduled: ScheduleEntry[]
+    overrides: ScheduleEntry[]
+    final: ScheduleEntry[]
+  }
+}
+
+export const fetchScheduleEntries = async (
+  apiKey: string,
+  scheduleId: string,
+  entryWindowStart: Date,
+  entryWindowEnd: Date
+): Promise<ScheduleEntry[]> => {
+  const url = new URL(`${INCIDENT_IO_BASE_URL}/schedule_entries`)
+  url.searchParams.set("schedule_id", scheduleId)
+  url.searchParams.set("entry_window_start", entryWindowStart.toISOString())
+  url.searchParams.set("entry_window_end", entryWindowEnd.toISOString())
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "application/json",
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `incident.io schedule_entries request failed: ${response.status} ${response.statusText}`
+    )
+  }
+
+  const body = (await response.json()) as ScheduleEntriesResponse
+  return body.schedule_entries.final
+}
+
+const dedupeUsersById = (users: IncidentIoUser[]): IncidentIoUser[] => {
+  const byId = new Map(users.map(user => [user.id, user]))
+  return Array.from(byId.values())
+}
+
+// incident.io has no "who's on call right now" endpoint: the `final` array for
+// an omitted/wide window can include entries that aren't active at the moment
+// of the request. So we ask for a tight window straddling `now` and then
+// filter to entries whose [start_at, end_at) actually contains `now`.
+export const currentOnCallUsers = async (
+  apiKey: string,
+  scheduleId: string,
+  now: Date = new Date()
+): Promise<IncidentIoUser[]> => {
+  const windowEnd = new Date(now.getTime() + CURRENT_SHIFT_WINDOW_PADDING_MS)
+  const entries = await fetchScheduleEntries(apiKey, scheduleId, now, windowEnd)
+
+  const active = entries.filter(entry => {
+    const startsBeforeOrAtNow = Date.parse(entry.start_at) <= now.getTime()
+    const endsAfterNow = now.getTime() < Date.parse(entry.end_at)
+    return startsBeforeOrAtNow && endsAfterNow
+  })
+
+  return dedupeUsersById(active.map(entry => entry.user))
+}
+
+export const scheduleUrl = (scheduleId: string): string =>
+  `${INCIDENT_IO_APP_SCHEDULES_URL}/${scheduleId}`
+
+export const usersToMentions = (users: IncidentIoUser[]): string[] =>
+  users
+    .filter((user): user is IncidentIoUser & { slack_user_id: string } =>
+      Boolean(user.slack_user_id)
+    )
+    .map(user => `<@${user.slack_user_id}>`)

--- a/scripts/on-call/shift-boundary.test.ts
+++ b/scripts/on-call/shift-boundary.test.ts
@@ -1,0 +1,52 @@
+import { shiftBoundaryAnchor } from "./shift-boundary"
+
+describe("shiftBoundaryAnchor", () => {
+  it("anchors 1 second before the boundary during EDT (UTC-4)", () => {
+    // Monday 2026-07-13, 11:00am ET is EDT (UTC-4) -> 2026-07-13T15:00:00Z
+    const now = new Date("2026-07-13T15:04:00Z")
+
+    const anchor = shiftBoundaryAnchor({ weekday: 1, hour: 11 }, now)
+
+    expect(anchor.toISOString()).toBe("2026-07-13T14:59:59.000Z")
+  })
+
+  it("anchors 1 second before the boundary during EST (UTC-5)", () => {
+    // Monday 2026-01-12, 11:00am ET is EST (UTC-5) -> 2026-01-12T16:00:00Z
+    const now = new Date("2026-01-12T16:04:00Z")
+
+    const anchor = shiftBoundaryAnchor({ weekday: 1, hour: 11 }, now)
+
+    expect(anchor.toISOString()).toBe("2026-01-12T15:59:59.000Z")
+  })
+
+  it("anchors to the same boundary whether the job runs early or late", () => {
+    const runningEarly = new Date("2026-07-13T14:58:00Z") // 10:58am ET
+    const runningLate = new Date("2026-07-13T15:04:00Z") // 11:04am ET
+
+    const boundary = { weekday: 1, hour: 11 }
+
+    expect(shiftBoundaryAnchor(boundary, runningEarly).toISOString()).toBe(
+      shiftBoundaryAnchor(boundary, runningLate).toISOString()
+    )
+  })
+
+  it("throws when now's weekday (in the target timezone) doesn't match", () => {
+    const wednesday = new Date("2026-07-15T15:04:00Z")
+
+    expect(() =>
+      shiftBoundaryAnchor({ weekday: 1, hour: 11 }, wednesday)
+    ).toThrow("expected today to be weekday 1")
+  })
+
+  it("supports a custom timezone with a half-hour UTC offset", () => {
+    // Monday 2026-07-13, 11:00am IST (UTC+5:30) -> 2026-07-13T05:30:00Z
+    const now = new Date("2026-07-13T05:34:00Z")
+
+    const anchor = shiftBoundaryAnchor(
+      { weekday: 1, hour: 11, timeZone: "Asia/Kolkata" },
+      now
+    )
+
+    expect(anchor.toISOString()).toBe("2026-07-13T05:29:59.000Z")
+  })
+})

--- a/scripts/on-call/shift-boundary.ts
+++ b/scripts/on-call/shift-boundary.ts
@@ -100,7 +100,13 @@ const zonedTimeToUtc = (
   timeZone: string
 ): Date => {
   // A same-day guess is enough to know which offset applies (e.g. EDT vs
-  // EST) — it doesn't need to be exact.
+  // EST) — it doesn't need to be exact. Caveat: the offset is looked up at
+  // the guess, not at the true target instant, so a target hour whose
+  // wall-clock lands very close to the DST transition itself (2am local, in
+  // the US) could resolve the offset from the wrong side of that transition
+  // on the transition day. Not a concern for the 11am boundary this module
+  // is built for, but worth knowing before reusing this for a boundary near
+  // 1am-3am local time.
   const roughGuess = Date.UTC(year, month - 1, day, hour, minute, second)
   const offset = utcOffsetMinutes(timeZone, new Date(roughGuess))
   // Local time = UTC time + offset, so UTC time = local time - offset.

--- a/scripts/on-call/shift-boundary.ts
+++ b/scripts/on-call/shift-boundary.ts
@@ -1,0 +1,139 @@
+// Anchors "who was on-call as of a shift-change boundary" to a fixed instant
+// derived from that boundary's calendar day, rather than the literal
+// execution time of the caller. GitHub's `schedule` trigger can fire a few
+// minutes late; without this, a late-firing job could cross the boundary and
+// pick up the incoming shift instead of the outgoing one it's meant to report.
+//
+// Boundaries are defined in local wall-clock time (e.g. "11am ET"), but the
+// API this feeds only understands UTC instants, so this file also converts
+// between the two — DST included — using `Intl`, with no external dependency.
+
+const DEFAULT_TIME_ZONE = "America/New_York"
+
+// How far before a shift-change boundary to anchor, so that an exact-instant
+// match resolves to the outgoing shift rather than the incoming one.
+const BOUNDARY_SAFETY_MARGIN_MS = 1_000
+
+export interface ShiftBoundary {
+  weekday: number // 0 (Sun) - 6 (Sat), Date#getDay convention
+  hour: number // 0-23, local time in `timeZone`
+  timeZone?: string // IANA name, default "America/New_York"
+}
+
+interface CivilDateTime {
+  year: number
+  month: number
+  day: number
+  weekday: number
+  hour: number
+  minute: number
+  second: number
+}
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+}
+
+const civilDateTimeIn = (timeZone: string, instant: Date): CivilDateTime => {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "short",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  })
+
+  const parts: Record<string, string> = {}
+  for (const part of formatter.formatToParts(instant)) {
+    parts[part.type] = part.value
+  }
+
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day),
+    weekday: WEEKDAY_INDEX[parts.weekday],
+    hour: Number(parts.hour),
+    minute: Number(parts.minute),
+    second: Number(parts.second),
+  }
+}
+
+// Returns the UTC offset (in minutes) that `timeZone` observes at `instant`.
+// e.g. America/New_York is -240 in summer (EDT) and -300 in winter (EST) —
+// `Intl` resolves which one applies for this exact date from the IANA
+// timezone database, so this is DST-aware without a lookup table.
+const utcOffsetMinutes = (timeZone: string, instant: Date): number => {
+  const offsetName =
+    new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      timeZoneName: "shortOffset",
+    })
+      .formatToParts(instant)
+      .find(part => part.type === "timeZoneName")?.value ?? "GMT"
+
+  // "GMT-4" -> -240, "GMT+5:30" -> 330, "GMT" -> 0
+  const match = offsetName.match(/GMT(?:([+-])(\d+)(?::(\d+))?)?/)
+  const [, sign, hours = "0", minutes = "0"] = match ?? []
+  const magnitude = Number(hours) * 60 + Number(minutes)
+  return sign === "-" ? -magnitude : magnitude
+}
+
+// Converts a wall-clock time in `timeZone` to the UTC instant it represents.
+const zonedTimeToUtc = (
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  timeZone: string
+): Date => {
+  // A same-day guess is enough to know which offset applies (e.g. EDT vs
+  // EST) — it doesn't need to be exact.
+  const roughGuess = Date.UTC(year, month - 1, day, hour, minute, second)
+  const offset = utcOffsetMinutes(timeZone, new Date(roughGuess))
+  // Local time = UTC time + offset, so UTC time = local time - offset.
+  return new Date(roughGuess - offset * 60_000)
+}
+
+// Deterministic anchor for "who was on-call up to this boundary" — independent
+// of how late the caller actually happens to run relative to the boundary.
+// Only `now`'s calendar day (in `timeZone`) is used; the target hour is fixed,
+// so a job running a few minutes early or late on the right day still anchors
+// to the same instant.
+export const shiftBoundaryAnchor = (
+  boundary: ShiftBoundary,
+  now: Date = new Date()
+): Date => {
+  const timeZone = boundary.timeZone ?? DEFAULT_TIME_ZONE
+  const civil = civilDateTimeIn(timeZone, now)
+
+  if (civil.weekday !== boundary.weekday) {
+    throw new Error(
+      `shiftBoundaryAnchor expected today to be weekday ${boundary.weekday} in ${timeZone}, but it's ${civil.weekday}.`
+    )
+  }
+
+  const boundaryInstant = zonedTimeToUtc(
+    civil.year,
+    civil.month,
+    civil.day,
+    boundary.hour,
+    0,
+    0,
+    timeZone
+  )
+
+  return new Date(boundaryInstant.getTime() - BOUNDARY_SAFETY_MARGIN_MS)
+}

--- a/scripts/on-call/standup-reminder.test.ts
+++ b/scripts/on-call/standup-reminder.test.ts
@@ -1,0 +1,153 @@
+import * as fs from "fs"
+import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
+import { shiftBoundaryAnchor } from "./shift-boundary"
+import { buildPayload, main } from "./standup-reminder"
+
+jest.mock("fs")
+jest.mock("./incident-io")
+jest.mock("./shift-boundary")
+
+const mockFs = fs as jest.Mocked<typeof fs>
+const mockCurrentOnCallUsers = currentOnCallUsers as jest.Mock
+const mockUsersToMentions = usersToMentions as jest.Mock
+const mockScheduleUrl = scheduleUrl as jest.Mock
+const mockShiftBoundaryAnchor = shiftBoundaryAnchor as jest.Mock
+
+const ANCHOR = new Date("2026-07-13T14:59:59.000Z")
+
+const SCHEDULE_URL =
+  "https://app.incident.io/artsy/on-call/schedules/schedule-123"
+
+describe("buildPayload", () => {
+  it("preserves the standup reminder wording with mentions joined by 'and'", () => {
+    const payload = JSON.parse(
+      buildPayload(["<@U_ALICE>", "<@U_BOB>"], SCHEDULE_URL)
+    )
+
+    expect(payload.blocks).toHaveLength(1)
+    const text = payload.blocks[0].text.text
+    expect(text).toContain("Hi <@U_ALICE> and <@U_BOB> :wave:")
+    expect(text).toContain(`<${SCHEDULE_URL}|on-call schedule>`)
+    expect(text).toContain(
+      "you've been chosen to facilitate today's Engineering Standup at 11:45am ET."
+    )
+    expect(text).toContain(
+      "<https://github.com/artsy/README/blob/main/events/open-standup.md|on GitHub>"
+    )
+    expect(text).toContain(
+      "<https://www.notion.so/artsy/Standup-Notes-28a5dfe4864645788de1ef936f39687c|in Notion>"
+    )
+  })
+
+  it("handles a single mention", () => {
+    const payload = JSON.parse(buildPayload(["<@U_ALICE>"], SCHEDULE_URL))
+
+    expect(payload.blocks[0].text.text).toContain("Hi <@U_ALICE> :wave:")
+  })
+})
+
+describe("main", () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv, GITHUB_OUTPUT: undefined }
+    mockCurrentOnCallUsers.mockResolvedValue([])
+    mockUsersToMentions.mockReturnValue(["<@U_ALICE>"])
+    mockScheduleUrl.mockReturnValue(SCHEDULE_URL)
+    mockShiftBoundaryAnchor.mockReturnValue(ANCHOR)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it("throws when INCIDENT_IO_API_KEY is not set", async () => {
+    delete process.env.INCIDENT_IO_API_KEY
+    process.env.SCHEDULE_ID = "schedule-123"
+
+    await expect(main()).rejects.toThrow(
+      "INCIDENT_IO_API_KEY env var is not set."
+    )
+  })
+
+  it("throws when SCHEDULE_ID is not set", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    delete process.env.SCHEDULE_ID
+
+    await expect(main()).rejects.toThrow("SCHEDULE_ID env var is not set.")
+  })
+
+  it("logs the payload to stdout when GITHUB_OUTPUT is unset", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(mockShiftBoundaryAnchor).toHaveBeenCalledWith({
+      weekday: 1,
+      hour: 11,
+    })
+    expect(mockCurrentOnCallUsers).toHaveBeenCalledWith(
+      "test-key",
+      "schedule-123",
+      ANCHOR
+    )
+    expect(mockScheduleUrl).toHaveBeenCalledWith("schedule-123")
+    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(consoleSpy.mock.calls[0][0]).toContain("<@U_ALICE>")
+    expect(consoleSpy.mock.calls[0][0]).toContain(SCHEDULE_URL)
+    consoleSpy.mockRestore()
+  })
+
+  it("uses STANDUP_BOUNDARY_WEEKDAY/STANDUP_BOUNDARY_HOUR when set", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.STANDUP_BOUNDARY_WEEKDAY = "3"
+    process.env.STANDUP_BOUNDARY_HOUR = "9"
+    jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(mockShiftBoundaryAnchor).toHaveBeenCalledWith({
+      weekday: 3,
+      hour: 9,
+    })
+  })
+
+  it("throws when STANDUP_BOUNDARY_WEEKDAY is out of range", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.STANDUP_BOUNDARY_WEEKDAY = "7"
+
+    await expect(main()).rejects.toThrow(
+      'Invalid STANDUP_BOUNDARY_WEEKDAY: "7". Must be an integer between 0 and 6.'
+    )
+  })
+
+  it("throws when STANDUP_BOUNDARY_HOUR is out of range", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.STANDUP_BOUNDARY_HOUR = "24"
+
+    await expect(main()).rejects.toThrow(
+      'Invalid STANDUP_BOUNDARY_HOUR: "24". Must be an integer between 0 and 23.'
+    )
+  })
+
+  it("writes the payload to GITHUB_OUTPUT using the heredoc delimiter form", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.GITHUB_OUTPUT = "/tmp/fake-output"
+    mockFs.appendFileSync.mockImplementation(() => undefined)
+
+    await main()
+
+    expect(mockFs.appendFileSync).toHaveBeenCalledTimes(1)
+    const [outputPath, contents] = mockFs.appendFileSync.mock.calls[0]
+    expect(outputPath).toBe("/tmp/fake-output")
+    expect(contents).toMatch(/^payload<<EOF_\d+\n/)
+    expect(contents).toContain("<@U_ALICE>")
+  })
+})

--- a/scripts/on-call/standup-reminder.test.ts
+++ b/scripts/on-call/standup-reminder.test.ts
@@ -44,6 +44,25 @@ describe("buildPayload", () => {
 
     expect(payload.blocks[0].text.text).toContain("Hi <@U_ALICE> :wave:")
   })
+
+  it("posts a 'no one on call' notice when there are no mentions", () => {
+    const payload = JSON.parse(buildPayload([], SCHEDULE_URL))
+
+    expect(payload.blocks).toHaveLength(1)
+    const text = payload.blocks[0].text.text
+    expect(text).not.toContain("Hi  :wave:")
+    expect(text).toContain("No one appears to be on-call")
+    expect(text).toContain(`<${SCHEDULE_URL}|on-call schedule>`)
+    expect(text).toContain(
+      "please make sure someone facilitates today's Engineering Standup at 11:45am ET."
+    )
+    expect(text).toContain(
+      "<https://github.com/artsy/README/blob/main/events/open-standup.md|on GitHub>"
+    )
+    expect(text).toContain(
+      "<https://www.notion.so/artsy/Standup-Notes-28a5dfe4864645788de1ef936f39687c|in Notion>"
+    )
+  })
 })
 
 describe("main", () => {
@@ -98,6 +117,21 @@ describe("main", () => {
     expect(consoleSpy).toHaveBeenCalledTimes(1)
     expect(consoleSpy.mock.calls[0][0]).toContain("<@U_ALICE>")
     expect(consoleSpy.mock.calls[0][0]).toContain(SCHEDULE_URL)
+    consoleSpy.mockRestore()
+  })
+
+  it("still posts a 'no one on call' payload when there are no mentions", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    mockUsersToMentions.mockReturnValue([])
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(consoleSpy.mock.calls[0][0]).toContain(
+      "No one appears to be on-call"
+    )
     consoleSpy.mockRestore()
   })
 

--- a/scripts/on-call/standup-reminder.ts
+++ b/scripts/on-call/standup-reminder.ts
@@ -1,0 +1,102 @@
+import * as fs from "fs"
+
+import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
+import { shiftBoundaryAnchor } from "./shift-boundary"
+
+const DEFAULT_BOUNDARY_WEEKDAY = 1 // Monday
+const DEFAULT_BOUNDARY_HOUR = 11 // 11am ET
+
+const URLS = {
+  standup: "https://github.com/artsy/README/blob/main/events/open-standup.md",
+  notes:
+    "https://www.notion.so/artsy/Standup-Notes-28a5dfe4864645788de1ef936f39687c",
+}
+
+export const buildPayload = (
+  mentions: string[],
+  onCallScheduleUrl: string
+): string =>
+  JSON.stringify({
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `Hi ${mentions.join(" and ")} :wave:\n\nBased on our <${
+            onCallScheduleUrl
+          }|on-call schedule>, you've been chosen to facilitate today's Engineering Standup at 11:45am ET. Please refer to the docs <${
+            URLS.standup
+          }|on GitHub> and add new standup notes <${URLS.notes}|in Notion>.`,
+        },
+      },
+    ],
+  })
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} env var is not set.`)
+  }
+  return value
+}
+
+const readIntEnv = (
+  name: string,
+  defaultValue: number,
+  range: { min: number; max: number }
+): number => {
+  const raw = process.env[name]
+  const value = raw ? Number.parseInt(raw, 10) : defaultValue
+
+  if (Number.isNaN(value) || value < range.min || value > range.max) {
+    throw new Error(
+      `Invalid ${name}: "${raw}". Must be an integer between ${range.min} and ${range.max}.`
+    )
+  }
+
+  return value
+}
+
+export const main = async (): Promise<void> => {
+  const apiKey = requireEnv("INCIDENT_IO_API_KEY")
+  const scheduleId = requireEnv("SCHEDULE_ID")
+  const boundaryWeekday = readIntEnv(
+    "STANDUP_BOUNDARY_WEEKDAY",
+    DEFAULT_BOUNDARY_WEEKDAY,
+    { min: 0, max: 6 }
+  )
+  const boundaryHour = readIntEnv(
+    "STANDUP_BOUNDARY_HOUR",
+    DEFAULT_BOUNDARY_HOUR,
+    {
+      min: 0,
+      max: 23,
+    }
+  )
+
+  const anchor = shiftBoundaryAnchor({
+    weekday: boundaryWeekday,
+    hour: boundaryHour,
+  })
+  const users = await currentOnCallUsers(apiKey, scheduleId, anchor)
+  const mentions = usersToMentions(users)
+  const payload = buildPayload(mentions, scheduleUrl(scheduleId))
+
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (outputPath) {
+    const delimiter = `EOF_${Date.now()}`
+    fs.appendFileSync(
+      outputPath,
+      `payload<<${delimiter}\n${payload}\n${delimiter}\n`
+    )
+  } else {
+    console.log(payload)
+  }
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/scripts/on-call/standup-reminder.ts
+++ b/scripts/on-call/standup-reminder.ts
@@ -15,22 +15,30 @@ const URLS = {
 export const buildPayload = (
   mentions: string[],
   onCallScheduleUrl: string
-): string =>
-  JSON.stringify({
+): string => {
+  // currentOnCallUsers/usersToMentions can legitimately return nobody (a
+  // schedule gap, or on-call users missing a linked Slack account) — post an
+  // explicit "no one on call" notice instead of a message that silently tags
+  // no one.
+  const intro =
+    mentions.length > 0
+      ? `Hi ${mentions.join(" and ")} :wave:\n\nBased on our <${
+          onCallScheduleUrl
+        }|on-call schedule>, you've been chosen to facilitate today's Engineering Standup at 11:45am ET.`
+      : `:warning: No one appears to be on-call according to our <${onCallScheduleUrl}|on-call schedule> — please make sure someone facilitates today's Engineering Standup at 11:45am ET.`
+
+  return JSON.stringify({
     blocks: [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `Hi ${mentions.join(" and ")} :wave:\n\nBased on our <${
-            onCallScheduleUrl
-          }|on-call schedule>, you've been chosen to facilitate today's Engineering Standup at 11:45am ET. Please refer to the docs <${
-            URLS.standup
-          }|on GitHub> and add new standup notes <${URLS.notes}|in Notion>.`,
+          text: `${intro} Please refer to the docs <${URLS.standup}|on GitHub> and add new standup notes <${URLS.notes}|in Notion>.`,
         },
       },
     ],
   })
+}
 
 const requireEnv = (name: string): string => {
   const value = process.env[name]


### PR DESCRIPTION
## Summary
- Adds `scripts/on-call/` (incident.io API client, DST-aware shift-boundary anchoring, and the standup-reminder script) plus a new `incident-standup-reminder.yml` reusable workflow, replacing Opsgenie + Slack email-lookup with incident.io's `slack_user_id` directly.
- Anchors the "who's on-call" query to a deterministic shift-change boundary (configurable via `boundary-weekday`/`boundary-hour` inputs, default Monday 11am ET) instead of literal execution time, so a late-firing cron can't accidentally pick up the incoming shift instead of the outgoing one.
- Phase 1 of migrating artsy/cli's 3 Opsgenie-based on-call notifiers off Opsgenie; `next-on-call` and `facilitate-incident-review` follow in later PRs. artsy/cli itself is untouched.

## Test plan
- [x] 21 new tests added (`scripts/on-call/`), all passing
- [x] Full suite (60 total) passing — no regressions in existing scripts
- [x] `yarn biome check` / `tsc --noEmit` clean
- [x] Verified end-to-end against the real incident.io API and real schedule data (local run)
- [ ] Verify in production via `workflow_dispatch` on joule's updated workflow once this merges

Assisted-by: Claude:Sonnet-5 [Claude Code]