### PR TITLE
ci: skip Claude review for PRs with in-progress label

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,12 +20,13 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    # Fast-path exclusions: drafts, bots, dependabot, renovate (zero overhead)
+    # Fast-path exclusions: drafts, bots, dependabot, renovate, in-progress label (zero overhead)
     if: |
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.user.login, '[bot]') &&
       github.event.pull_request.user.login != 'dependabot' &&
-      github.event.pull_request.user.login != 'renovate'
+      github.event.pull_request.user.login != 'renovate' &&
+      !contains(github.event.pull_request.labels.*.name, 'in-progress')
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,7 +26,8 @@ jobs:
       !contains(github.event.pull_request.user.login, '[bot]') &&
       github.event.pull_request.user.login != 'dependabot' &&
       github.event.pull_request.user.login != 'renovate' &&
-      !contains(github.event.pull_request.labels.*.name, 'in-progress')
+      !contains(github.event.pull_request.labels.*.name, 'in-progress') &&
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled' || github.event.label.name == 'in-progress')
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/run-claude-review.yml
+++ b/.github/workflows/run-claude-review.yml
@@ -2,7 +2,7 @@ name: AI PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled, unlabeled]
 
 jobs:
   claude-review:

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -215,6 +215,7 @@ secrets:
   - Bot authors (dependabot, renovate, usernames containing `[bot]`)
   - PRs titled exactly "Deploy"
   - PRs with "graphql schema" in the title
+  - PRs labeled `in-progress` (requires `labeled`/`unlabeled` in the caller's trigger `types`, see below)
 
 **Inputs:**
 
@@ -280,7 +281,7 @@ exclude:
 
 Default exclusions:
 
-- **Always excluded** (cannot be disabled): Draft PRs, bots (username contains `[bot]`), `dependabot`, `renovate`
+- **Always excluded** (cannot be disabled): Draft PRs, bots (username contains `[bot]`), `dependabot`, `renovate`, PRs labeled `in-progress`
 - **Title patterns** (disabled with `disable_defaults: true`): `^Deploy$` (exact match), `graphql schema` (contains)
 
 **Complete Prompt Override:**
@@ -310,12 +311,14 @@ prompt: |
 ```yaml
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled, unlabeled]
     # Optional: skip docs-only PRs to reduce costs
     paths-ignore:
       - "**.md"
       - "docs/**"
 ```
+
+`labeled`/`unlabeled` are required for the `in-progress` label exclusion below to take effect as soon as the label is added or removed, rather than waiting for the next push.
 
 ---
 

--- a/templates/run-claude-review.yml
+++ b/templates/run-claude-review.yml
@@ -2,7 +2,7 @@ name: AI PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled, unlabeled]
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary
Updated the Claude review workflow to skip code review for pull requests marked with the `in-progress` label, reducing unnecessary review overhead for work-in-progress changes.

## Changes
- Added `in-progress` label to the fast-path exclusions in the Claude review workflow
- Updated the conditional check to filter out PRs containing the `in-progress` label using `!contains(github.event.pull_request.labels.*.name, 'in-progress')`
- Updated the comment to reflect the new exclusion criteria

## Details
This change allows developers to mark PRs as in-progress to prevent triggering the automated Claude review until they're ready for feedback. The label check is added to the existing fast-path exclusions (drafts, bots, dependabot, renovate) which have zero overhead, keeping the workflow efficient.

https://claude.ai/code/session_01EDFGEzhCLzkKBShZyHDRPh