### PR TITLE
ci: cancel running Claude review when in-progress label is added

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,8 +18,22 @@ on:
         type: number
 
 jobs:
+  # Adding the in-progress label joins the shared concurrency group, which
+  # cancels any check/review job already running for this PR.
+  cancel-on-in-progress:
+    if: github.event.action == 'labeled' && github.event.label.name == 'in-progress'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: claude-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "in-progress label added, cancelled any running review"
+
   check:
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     # Fast-path exclusions: drafts, bots, dependabot, renovate, in-progress label (zero overhead)
     if: |
       github.event.pull_request.draft == false &&


### PR DESCRIPTION
## What

Adds a `cancel-on-in-progress` job to the reusable `claude-review.yml` workflow and puts the `check` job in the review's concurrency group.

## Why

The existing `in-progress` skip reads `github.event.pull_request.labels`, a snapshot taken when the run was triggered. If someone opens a PR and adds the label a minute later, the review is already running and nothing stops it. `cancel-in-progress: true` only fires when a new job joins the group, and label events never did.

## How it works

When the `in-progress` label is added, the `labeled` event skips `check` (fast-path `if`) but starts the new cancel job. That job joins the group `claude-review-<repo>-<pr>` with `cancel-in-progress: true`, so GitHub cancels whatever is running there: `check` if the run is still in setup, or `review` if it already started. The job then exits in seconds. No extra permissions, no API calls.

Removing the label behaves as before: the `unlabeled` event passes the fast-path and starts a fresh review.

```mermaid
flowchart TD
    E[PR event] --> A{action}
    A -- "opened / synchronize /<br/>ready_for_review" --> C["check job<br/>(now in concurrency group)"]
    C --> R["review job<br/>(already in group)"]
    A -- "labeled: in-progress" --> X["cancel-on-in-progress job<br/>joins same group,<br/>cancel-in-progress: true"]
    X -. "cancels if running" .-> C
    X -. "cancels if running" .-> R
    A -- "unlabeled: in-progress" --> C
```

## Who does this affec
Repos that are relying on `in-progress` label. Currently, only eigen.


Assisted-by: Claude:Fable-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)