### PR TITLE
feat: add incident.io next-on-call workflow

### DIFF
--- a/.github/workflows/incident-next-on-call.yml
+++ b/.github/workflows/incident-next-on-call.yml
@@ -16,25 +16,13 @@ on:
         default: "22"
         required: false
         type: string
-      rotation-boundary-weekday:
-        description: "Day the rot-na/sa on-call shift changes, 0 (Sun) - 6 (Sat). Default: 1 (Monday)"
-        default: 1
-        required: false
+      target-weekday:
+        description: "Weekday to look ahead to, 0 (Sun) - 6 (Sat). Callers running on multiple cron schedules should call this workflow once per schedule, each with its own literal target — e.g. the real rotation boundary for a run right before it, or a further-out generous cutoff for a run right after it."
+        required: true
         type: number
-      rotation-boundary-hour:
-        description: "Hour the rot-na/sa on-call shift changes, 0-23, America/New_York time. Default: 11 (11am ET)"
-        default: 11
-        required: false
-        type: number
-      safety-cutoff-weekday:
-        description: "Generous lookahead cutoff for the Monday run, 0 (Sun) - 6 (Sat). Default: 5 (Friday)"
-        default: 5
-        required: false
-        type: number
-      safety-cutoff-hour:
-        description: "Hour of the safety cutoff, 0-23, America/New_York time. Default: 0 (midnight ET)"
-        default: 0
-        required: false
+      target-hour:
+        description: "Hour of the target, 0-23, America/New_York time"
+        required: true
         type: number
 
 jobs:
@@ -70,10 +58,8 @@ jobs:
         env:
           INCIDENT_IO_API_KEY: ${{ secrets.incident-io-api-key }}
           SCHEDULE_ID: ${{ inputs.schedule-id }}
-          NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY: ${{ inputs.rotation-boundary-weekday }}
-          NEXT_ON_CALL_ROTATION_BOUNDARY_HOUR: ${{ inputs.rotation-boundary-hour }}
-          NEXT_ON_CALL_SAFETY_CUTOFF_WEEKDAY: ${{ inputs.safety-cutoff-weekday }}
-          NEXT_ON_CALL_SAFETY_CUTOFF_HOUR: ${{ inputs.safety-cutoff-hour }}
+          NEXT_ON_CALL_TARGET_WEEKDAY: ${{ inputs.target-weekday }}
+          NEXT_ON_CALL_TARGET_HOUR: ${{ inputs.target-hour }}
 
       - name: Next On Call > Slack
         if: steps.cli.outputs.payload != ''

--- a/.github/workflows/incident-next-on-call.yml
+++ b/.github/workflows/incident-next-on-call.yml
@@ -1,0 +1,85 @@
+name: Incident.io Next On Call
+
+on:
+  workflow_call:
+    secrets:
+      incident-io-api-key:
+        required: true
+      slack-webhook-url:
+        required: true
+    inputs:
+      schedule-id:
+        description: "incident.io schedule ID for the Engineering on-call schedule"
+        required: true
+        type: string
+      node-version:
+        default: "22"
+        required: false
+        type: string
+      rotation-boundary-weekday:
+        description: "Day the rot-na/sa on-call shift changes, 0 (Sun) - 6 (Sat). Default: 1 (Monday)"
+        default: 1
+        required: false
+        type: number
+      rotation-boundary-hour:
+        description: "Hour the rot-na/sa on-call shift changes, 0-23, America/New_York time. Default: 11 (11am ET)"
+        default: 11
+        required: false
+        type: number
+      safety-cutoff-weekday:
+        description: "Generous lookahead cutoff for the Monday run, 0 (Sun) - 6 (Sat). Default: 5 (Friday)"
+        default: 5
+        required: false
+        type: number
+      safety-cutoff-hour:
+        description: "Hour of the safety cutoff, 0-23, America/New_York time. Default: 0 (midnight ET)"
+        default: 0
+        required: false
+        type: number
+
+jobs:
+  next-on-call:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout tooling repo
+        uses: actions/checkout@v4
+        with:
+          repository: artsy/duchamp
+          ref: main
+          path: .tooling
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install tooling dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: .tooling
+        env:
+          YARN_IGNORE_PATH: 1
+
+      - name: Run next on-call
+        id: cli
+        run: .tooling/node_modules/.bin/ts-node .tooling/scripts/on-call/next-on-call.ts
+        env:
+          INCIDENT_IO_API_KEY: ${{ secrets.incident-io-api-key }}
+          SCHEDULE_ID: ${{ inputs.schedule-id }}
+          NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY: ${{ inputs.rotation-boundary-weekday }}
+          NEXT_ON_CALL_ROTATION_BOUNDARY_HOUR: ${{ inputs.rotation-boundary-hour }}
+          NEXT_ON_CALL_SAFETY_CUTOFF_WEEKDAY: ${{ inputs.safety-cutoff-weekday }}
+          NEXT_ON_CALL_SAFETY_CUTOFF_HOUR: ${{ inputs.safety-cutoff-hour }}
+
+      - name: Next On Call > Slack
+        if: steps.cli.outputs.payload != ''
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: ${{ steps.cli.outputs.payload }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -424,11 +424,6 @@ on:
     - cron: "0 14 * * THU"
 
 jobs:
-  # Runs on the primary rotation's handoff day (Monday) — the cron fires
-  # at 10am ET, before the actual 11am ET boundary. Targets a generous
-  # cutoff (Friday, midnight ET) rather than the next real boundary, so
-  # coverage still extends past the Thursday run below even if that run
-  # ends up firing late.
   monday-safety-cutoff:
     if: github.event.schedule == '0 14 * * MON'
     uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main
@@ -440,8 +435,6 @@ jobs:
       incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  # Runs a few days before the primary rotation's handoff (Thursday).
-  # Targets that real boundary (Monday, 11am ET) directly.
   thursday-rotation-boundary:
     if: github.event.schedule == '0 14 * * THU'
     uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main
@@ -454,10 +447,12 @@ jobs:
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 
+The specific values above reflect one real cadence (a generous Friday-midnight cutoff for the handoff-day run, a tight Monday-11am-ET target for the other) — see joule's `next-on-call.yml` for the fully-annotated production version.
+
 **Features:**
 
 - Queries incident.io's `/v2/schedule_entries` for a forward-looking window and includes only entries whose shift hasn't started yet (`start_at` after the run instant) — covers both regularly scheduled shifts and overrides, since incident.io merges both into the `final` array
-- Looks ahead to a single caller-supplied `target-weekday`/`target-hour`, resolved to a deterministic UTC instant (DST-aware) regardless of the workflow's literal execution time — the workflow itself has no notion of "which day is this" or what the target means; that mapping lives entirely in the calling job's config, as in the two-job example above
+- Looks ahead to a single caller-supplied `target-weekday`/`target-hour`, resolved to a deterministic UTC instant (DST-aware) regardless of the workflow's literal execution time — the workflow itself has no notion of "which day is this" or what the target means; that mapping lives entirely in the calling job's config
 - A small internal margin is added past the target instant, so a shift starting exactly at that boundary is still included
 - Silently skips posting to Slack (logs to the run's console output instead) when no one has an upcoming shift in the window, rather than posting an empty or awkward "nobody's up next" message
 - Builds Slack mentions directly from each schedule entry's `slack_user_id` — no separate email-to-Slack-ID lookup step

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -415,29 +415,49 @@ secrets:
 
 **Purpose**: Post a Slack reminder to engineers whose on-call shift is starting soon, so they can prepare
 
-**Use Case**: Scheduled workflows (e.g. running Monday and Thursday) that need to give advance notice of upcoming on-call shifts, sourced from an incident.io schedule with multiple rotations
+**Use Case**: Scheduled workflows that need to give advance notice of upcoming on-call shifts, sourced from an incident.io schedule. Intended to be called **once per cron schedule** the caller runs on, each call passing its own literal target — see the two-job example below
 
 ```yaml
-uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main
-with:
-  schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
-  node-version: "22"
-  rotation-boundary-weekday: 1
-  rotation-boundary-hour: 11
-  safety-cutoff-weekday: 5
-  safety-cutoff-hour: 0
-secrets:
-  incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
-  slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+on:
+  schedule:
+    - cron: "0 14 * * MON"
+    - cron: "0 14 * * THU"
+
+jobs:
+  # Runs right after the primary rotation's handoff (Monday). Targets a
+  # generous cutoff (Friday, midnight ET) rather than the next real
+  # boundary, so coverage still extends past the Thursday run below even
+  # if that run ends up firing late.
+  monday-safety-cutoff:
+    if: github.event.schedule == '0 14 * * MON'
+    uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main
+    with:
+      schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
+      target-weekday: 5 # Friday
+      target-hour: 0 # midnight ET
+    secrets:
+      incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # Runs a few days before the primary rotation's handoff (Thursday).
+  # Targets that real boundary (Monday, 11am ET) directly.
+  thursday-rotation-boundary:
+    if: github.event.schedule == '0 14 * * THU'
+    uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main
+    with:
+      schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
+      target-weekday: 1 # Monday
+      target-hour: 11 # 11am ET
+    secrets:
+      incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 
 **Features:**
 
 - Queries incident.io's `/v2/schedule_entries` for a forward-looking window and includes only entries whose shift hasn't started yet (`start_at` after the run instant) — covers both regularly scheduled shifts and overrides, since incident.io merges both into the `final` array
-- Built for a workflow that runs on two different days per week (e.g. Monday and Thursday), each targeting a different forward boundary so nothing slips through unannounced:
-  - On the day matching the actual rotation handoff's weekday (`rotation-boundary-weekday`, e.g. Monday), it looks ahead to a generous `safety-cutoff-weekday`/`safety-cutoff-hour` (default Friday midnight ET) rather than the next rotation boundary directly — this leaves a buffer in case the other scheduled run (e.g. Thursday) ends up firing late
-  - On the other day (e.g. Thursday), it looks ahead tightly to the next `rotation-boundary-weekday`/`rotation-boundary-hour` occurrence, plus a small internal margin, so a shift starting exactly at that boundary instant is still included
-  - Which of the two behaviors applies is determined by comparing the real weekday (in America/New_York time) the workflow is running on against fixed Monday/Thursday constants in the script — not configurable, since it's tied to the workflow's own cron schedule
+- Looks ahead to a single caller-supplied `target-weekday`/`target-hour`, resolved to a deterministic UTC instant (DST-aware) regardless of the workflow's literal execution time — the workflow itself has no notion of "which day is this" or what the target means; that mapping lives entirely in the calling job's config, as in the two-job example above
+- A small internal margin is added past the target instant, so a shift starting exactly at that boundary is still included
 - Silently skips posting to Slack (logs to the run's console output instead) when no one has an upcoming shift in the window, rather than posting an empty or awkward "nobody's up next" message
 - Builds Slack mentions directly from each schedule entry's `slack_user_id` — no separate email-to-Slack-ID lookup step
 
@@ -445,10 +465,8 @@ secrets:
 
 - `schedule-id` (required): incident.io schedule ID to query
 - `node-version` (optional): Node.js version to use
-- `rotation-boundary-weekday` (optional): Day of week the primary on-call rotation hands off, `0` (Sunday) through `6` (Saturday). Default: `1` (Monday)
-- `rotation-boundary-hour` (optional): Hour of day the primary rotation hands off, `0`-`23`, in America/New_York time. Default: `11` (11am ET)
-- `safety-cutoff-weekday` (optional): Day of week for the generous lookahead cutoff used on the rotation-boundary day itself. Default: `5` (Friday)
-- `safety-cutoff-hour` (optional): Hour of day for the safety cutoff, `0`-`23`, in America/New_York time. Default: `0` (midnight ET)
+- `target-weekday` (required): Day of week to look ahead to, `0` (Sunday) through `6` (Saturday)
+- `target-hour` (required): Hour of the target, `0`-`23`, in America/New_York time
 
 **Secrets:**
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -424,10 +424,11 @@ on:
     - cron: "0 14 * * THU"
 
 jobs:
-  # Runs right after the primary rotation's handoff (Monday). Targets a
-  # generous cutoff (Friday, midnight ET) rather than the next real
-  # boundary, so coverage still extends past the Thursday run below even
-  # if that run ends up firing late.
+  # Runs on the primary rotation's handoff day (Monday) — the cron fires
+  # at 10am ET, before the actual 11am ET boundary. Targets a generous
+  # cutoff (Friday, midnight ET) rather than the next real boundary, so
+  # coverage still extends past the Thursday run below even if that run
+  # ends up firing late.
   monday-safety-cutoff:
     if: github.event.schedule == '0 14 * * MON'
     uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -14,6 +14,7 @@ This document provides detailed reference information for all GitHub Actions ava
 | `run-claude-review.yml`              | AI-powered PR review           | For Claude-based code review        |
 | `link-pr-to-notion.yml`             | Link PRs to Notion tasks       | For repos using Notion task tracking |
 | `incident-standup-reminder.yml`      | Remind on-call to run standup  | For scheduled Slack standup reminders |
+| `incident-next-on-call.yml`          | Remind engineers of an upcoming on-call shift | For scheduled Slack next-on-call reminders |
 
 ## Action Reference
 
@@ -410,6 +411,52 @@ secrets:
 
 ---
 
+### incident-next-on-call.yml
+
+**Purpose**: Post a Slack reminder to engineers whose on-call shift is starting soon, so they can prepare
+
+**Use Case**: Scheduled workflows (e.g. running Monday and Thursday) that need to give advance notice of upcoming on-call shifts, sourced from an incident.io schedule with multiple rotations
+
+```yaml
+uses: artsy/duchamp/.github/workflows/incident-next-on-call.yml@main
+with:
+  schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
+  node-version: "22"
+  rotation-boundary-weekday: 1
+  rotation-boundary-hour: 11
+  safety-cutoff-weekday: 5
+  safety-cutoff-hour: 0
+secrets:
+  incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
+  slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+**Features:**
+
+- Queries incident.io's `/v2/schedule_entries` for a forward-looking window and includes only entries whose shift hasn't started yet (`start_at` after the run instant) — covers both regularly scheduled shifts and overrides, since incident.io merges both into the `final` array
+- Built for a workflow that runs on two different days per week (e.g. Monday and Thursday), each targeting a different forward boundary so nothing slips through unannounced:
+  - On the day matching the actual rotation handoff's weekday (`rotation-boundary-weekday`, e.g. Monday), it looks ahead to a generous `safety-cutoff-weekday`/`safety-cutoff-hour` (default Friday midnight ET) rather than the next rotation boundary directly — this leaves a buffer in case the other scheduled run (e.g. Thursday) ends up firing late
+  - On the other day (e.g. Thursday), it looks ahead tightly to the next `rotation-boundary-weekday`/`rotation-boundary-hour` occurrence, plus a small internal margin, so a shift starting exactly at that boundary instant is still included
+  - Which of the two behaviors applies is determined by comparing the real weekday (in America/New_York time) the workflow is running on against fixed Monday/Thursday constants in the script — not configurable, since it's tied to the workflow's own cron schedule
+- Silently skips posting to Slack (logs to the run's console output instead) when no one has an upcoming shift in the window, rather than posting an empty or awkward "nobody's up next" message
+- Builds Slack mentions directly from each schedule entry's `slack_user_id` — no separate email-to-Slack-ID lookup step
+
+**Inputs:**
+
+- `schedule-id` (required): incident.io schedule ID to query
+- `node-version` (optional): Node.js version to use
+- `rotation-boundary-weekday` (optional): Day of week the primary on-call rotation hands off, `0` (Sunday) through `6` (Saturday). Default: `1` (Monday)
+- `rotation-boundary-hour` (optional): Hour of day the primary rotation hands off, `0`-`23`, in America/New_York time. Default: `11` (11am ET)
+- `safety-cutoff-weekday` (optional): Day of week for the generous lookahead cutoff used on the rotation-boundary day itself. Default: `5` (Friday)
+- `safety-cutoff-hour` (optional): Hour of day for the safety cutoff, `0`-`23`, in America/New_York time. Default: `0` (midnight ET)
+
+**Secrets:**
+
+- `incident-io-api-key` (required): incident.io API key with access to the schedule
+- `slack-webhook-url` (required): Slack incoming webhook URL to post the reminder to
+
+---
+
 ## Reusable Action
 
 ### setup-and-install
@@ -451,6 +498,7 @@ secrets:
 | AI-powered code review          | `run-claude-review.yml`              | Uses Claude to review PRs            |
 | Notion task tracking            | `link-pr-to-notion.yml`             | Links PRs to Notion tasks by short ID |
 | Scheduled on-call Slack reminders | `incident-standup-reminder.yml`   | Sources current on-call from incident.io |
+| Scheduled upcoming on-call reminders | `incident-next-on-call.yml`    | Notifies engineers ahead of their shift starting |
 | Custom workflows                | `setup-and-install` action           | Use as a step in custom workflows    |
 
 ## Security Considerations

--- a/scripts/on-call/incident-io.test.ts
+++ b/scripts/on-call/incident-io.test.ts
@@ -2,6 +2,7 @@ import {
   currentOnCallUsers,
   fetchScheduleEntries,
   type IncidentIoUser,
+  nextOnCallUsers,
   type ScheduleEntry,
   scheduleUrl,
   usersToMentions,
@@ -135,6 +136,135 @@ describe("currentOnCallUsers", () => {
     const result = await currentOnCallUsers("api-key", "schedule-123", now)
 
     expect(result).toEqual([sharedUser])
+  })
+})
+
+describe("nextOnCallUsers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest.fn()
+  })
+
+  it("excludes shifts that have already started and includes upcoming ones", async () => {
+    const now = new Date("2026-07-30T15:00:00Z")
+    const alreadyStarted = entry({
+      start_at: "2026-07-27T15:00:00Z",
+      end_at: "2026-07-31T16:00:00Z",
+      user: user({ id: "already-started" }),
+    })
+    const upcomingOverride = entry({
+      start_at: "2026-07-31T16:00:00Z",
+      end_at: "2026-08-03T15:00:00Z",
+      user: user({ id: "upcoming-override" }),
+    })
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        schedule_entries: {
+          scheduled: [],
+          overrides: [],
+          final: [alreadyStarted, upcomingOverride],
+        },
+      })
+    )
+
+    const result = await nextOnCallUsers(
+      "api-key",
+      "schedule-123",
+      now,
+      new Date("2026-08-03T15:00:00Z")
+    )
+
+    expect(result).toEqual([upcomingOverride.user])
+  })
+
+  it("includes a shift starting exactly at the windowEnd boundary, thanks to the lookahead padding", async () => {
+    const now = new Date("2026-07-30T15:00:00Z")
+    const windowEnd = new Date("2026-08-03T15:00:00Z")
+    const exactlyAtBoundary = entry({
+      start_at: windowEnd.toISOString(),
+      end_at: "2026-08-10T15:00:00Z",
+      user: user({ id: "at-boundary" }),
+    })
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        schedule_entries: {
+          scheduled: [],
+          overrides: [],
+          final: [exactlyAtBoundary],
+        },
+      })
+    )
+
+    const result = await nextOnCallUsers(
+      "api-key",
+      "schedule-123",
+      now,
+      windowEnd
+    )
+
+    expect(result).toEqual([exactlyAtBoundary.user])
+    const [, options] = mockFetch.mock.calls[0]
+    const requestUrl = new URL(mockFetch.mock.calls[0][0])
+    expect(requestUrl.searchParams.get("entry_window_end")).toBe(
+      new Date(windowEnd.getTime() + 60_000).toISOString()
+    )
+    expect(options.headers.Authorization).toBe("Bearer api-key")
+  })
+
+  it("dedupes a user appearing in more than one upcoming entry", async () => {
+    const now = new Date("2026-07-30T15:00:00Z")
+    const sharedUser = user({ id: "shared-user" })
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        schedule_entries: {
+          scheduled: [],
+          overrides: [],
+          final: [
+            entry({
+              entry_id: "a",
+              start_at: "2026-07-31T16:00:00Z",
+              user: sharedUser,
+            }),
+            entry({
+              entry_id: "b",
+              start_at: "2026-08-01T00:00:00Z",
+              user: sharedUser,
+            }),
+          ],
+        },
+      })
+    )
+
+    const result = await nextOnCallUsers(
+      "api-key",
+      "schedule-123",
+      now,
+      new Date("2026-08-03T15:00:00Z")
+    )
+
+    expect(result).toEqual([sharedUser])
+  })
+
+  it("returns an empty array when nothing is upcoming in the window", async () => {
+    const now = new Date("2026-07-30T15:00:00Z")
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        schedule_entries: { scheduled: [], overrides: [], final: [] },
+      })
+    )
+
+    const result = await nextOnCallUsers(
+      "api-key",
+      "schedule-123",
+      now,
+      new Date("2026-08-03T15:00:00Z")
+    )
+
+    expect(result).toEqual([])
   })
 })
 

--- a/scripts/on-call/incident-io.ts
+++ b/scripts/on-call/incident-io.ts
@@ -6,6 +6,13 @@ const INCIDENT_IO_APP_SCHEDULES_URL =
 // risking that the window drifts into the next shift.
 const CURRENT_SHIFT_WINDOW_PADDING_MS = 60_000
 
+// incident.io's entry_window_end appears to be exclusive at the exact
+// instant: an entry whose start_at lands precisely on entry_window_end was
+// observed missing from `final` in a real query against production schedule
+// data. This small forward margin ensures a caller's intended boundary
+// instant is still captured.
+const NEXT_SHIFT_LOOKAHEAD_PADDING_MS = 60_000
+
 export interface IncidentIoUser {
   id: string
   name: string
@@ -83,6 +90,34 @@ export const currentOnCallUsers = async (
   })
 
   return dedupeUsersById(active.map(entry => entry.user))
+}
+
+// Entries whose shift has not yet started as of `now` — i.e. upcoming shifts
+// someone should get a heads-up about, whether regularly scheduled or an
+// override. `windowEnd` is the caller's intended boundary instant (e.g. from
+// `nextShiftBoundaryInstant`); a small forward margin is added internally so
+// an entry starting exactly at that instant is still included.
+export const nextOnCallUsers = async (
+  apiKey: string,
+  scheduleId: string,
+  now: Date,
+  windowEnd: Date
+): Promise<IncidentIoUser[]> => {
+  const paddedWindowEnd = new Date(
+    windowEnd.getTime() + NEXT_SHIFT_LOOKAHEAD_PADDING_MS
+  )
+  const entries = await fetchScheduleEntries(
+    apiKey,
+    scheduleId,
+    now,
+    paddedWindowEnd
+  )
+
+  const upcoming = entries.filter(
+    entry => now.getTime() < Date.parse(entry.start_at)
+  )
+
+  return dedupeUsersById(upcoming.map(entry => entry.user))
 }
 
 export const scheduleUrl = (scheduleId: string): string =>

--- a/scripts/on-call/next-on-call.test.ts
+++ b/scripts/on-call/next-on-call.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs"
 import { nextOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
 import { buildPayload, main } from "./next-on-call"
-import { nextShiftBoundaryInstant, weekdayInTimeZone } from "./shift-boundary"
+import { nextShiftBoundaryInstant } from "./shift-boundary"
 
 jest.mock("fs")
 jest.mock("./incident-io")
@@ -12,7 +12,6 @@ const mockNextOnCallUsers = nextOnCallUsers as jest.Mock
 const mockUsersToMentions = usersToMentions as jest.Mock
 const mockScheduleUrl = scheduleUrl as jest.Mock
 const mockNextShiftBoundaryInstant = nextShiftBoundaryInstant as jest.Mock
-const mockWeekdayInTimeZone = weekdayInTimeZone as jest.Mock
 
 const WINDOW_END = new Date("2026-08-03T15:00:00Z")
 
@@ -45,12 +44,16 @@ describe("main", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    process.env = { ...originalEnv, GITHUB_OUTPUT: undefined }
+    process.env = {
+      ...originalEnv,
+      GITHUB_OUTPUT: undefined,
+      NEXT_ON_CALL_TARGET_WEEKDAY: "1",
+      NEXT_ON_CALL_TARGET_HOUR: "11",
+    }
     mockNextOnCallUsers.mockResolvedValue([])
     mockUsersToMentions.mockReturnValue(["<@U_ALICE>"])
     mockScheduleUrl.mockReturnValue(SCHEDULE_URL)
     mockNextShiftBoundaryInstant.mockReturnValue(WINDOW_END)
-    mockWeekdayInTimeZone.mockReturnValue(1) // Monday by default
   })
 
   afterEach(() => {
@@ -73,10 +76,32 @@ describe("main", () => {
     await expect(main()).rejects.toThrow("SCHEDULE_ID env var is not set.")
   })
 
-  it("on a Monday run, targets the Friday safety cutoff (default weekday 5, hour 0)", async () => {
+  it("throws when NEXT_ON_CALL_TARGET_WEEKDAY is not set", async () => {
     process.env.INCIDENT_IO_API_KEY = "test-key"
     process.env.SCHEDULE_ID = "schedule-123"
-    mockWeekdayInTimeZone.mockReturnValue(1)
+    delete process.env.NEXT_ON_CALL_TARGET_WEEKDAY
+
+    await expect(main()).rejects.toThrow(
+      "NEXT_ON_CALL_TARGET_WEEKDAY env var is not set."
+    )
+  })
+
+  it("throws when NEXT_ON_CALL_TARGET_HOUR is not set", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.NEXT_ON_CALL_TARGET_WEEKDAY = "1"
+    delete process.env.NEXT_ON_CALL_TARGET_HOUR
+
+    await expect(main()).rejects.toThrow(
+      "NEXT_ON_CALL_TARGET_HOUR env var is not set."
+    )
+  })
+
+  it("computes the window end from the caller-supplied target weekday/hour", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.NEXT_ON_CALL_TARGET_WEEKDAY = "5"
+    process.env.NEXT_ON_CALL_TARGET_HOUR = "0"
     jest.spyOn(console, "log").mockImplementation()
 
     await main()
@@ -93,68 +118,25 @@ describe("main", () => {
     )
   })
 
-  it("on a Thursday run, targets the rot-na/sa rotation boundary (default weekday 1, hour 11)", async () => {
+  it("throws when NEXT_ON_CALL_TARGET_WEEKDAY is out of range", async () => {
     process.env.INCIDENT_IO_API_KEY = "test-key"
     process.env.SCHEDULE_ID = "schedule-123"
-    mockWeekdayInTimeZone.mockReturnValue(4)
-    jest.spyOn(console, "log").mockImplementation()
-
-    await main()
-
-    expect(mockNextShiftBoundaryInstant).toHaveBeenCalledWith(
-      { weekday: 1, hour: 11 },
-      expect.any(Date)
-    )
-  })
-
-  it("throws when run on a weekday other than Monday or Thursday", async () => {
-    process.env.INCIDENT_IO_API_KEY = "test-key"
-    process.env.SCHEDULE_ID = "schedule-123"
-    mockWeekdayInTimeZone.mockReturnValue(3) // Wednesday
+    process.env.NEXT_ON_CALL_TARGET_WEEKDAY = "7"
+    process.env.NEXT_ON_CALL_TARGET_HOUR = "11"
 
     await expect(main()).rejects.toThrow(
-      "expected to run on weekday 1 (Monday) or 4 (Thursday)"
+      'Invalid NEXT_ON_CALL_TARGET_WEEKDAY: "7". Must be an integer between 0 and 6.'
     )
   })
 
-  it("respects NEXT_ON_CALL_RUN_WEEKDAY_OVERRIDE for testing on a different real day", async () => {
+  it("throws when NEXT_ON_CALL_TARGET_HOUR is out of range", async () => {
     process.env.INCIDENT_IO_API_KEY = "test-key"
     process.env.SCHEDULE_ID = "schedule-123"
-    process.env.NEXT_ON_CALL_RUN_WEEKDAY_OVERRIDE = "4"
-    mockWeekdayInTimeZone.mockReturnValue(3) // real day would otherwise throw
-    jest.spyOn(console, "log").mockImplementation()
-
-    await main()
-
-    expect(mockNextShiftBoundaryInstant).toHaveBeenCalledWith(
-      { weekday: 1, hour: 11 },
-      expect.any(Date)
-    )
-  })
-
-  it("respects rotation/safety cutoff overrides", async () => {
-    process.env.INCIDENT_IO_API_KEY = "test-key"
-    process.env.SCHEDULE_ID = "schedule-123"
-    process.env.NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY = "3"
-    process.env.NEXT_ON_CALL_ROTATION_BOUNDARY_HOUR = "9"
-    mockWeekdayInTimeZone.mockReturnValue(4)
-    jest.spyOn(console, "log").mockImplementation()
-
-    await main()
-
-    expect(mockNextShiftBoundaryInstant).toHaveBeenCalledWith(
-      { weekday: 3, hour: 9 },
-      expect.any(Date)
-    )
-  })
-
-  it("throws when NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY is out of range", async () => {
-    process.env.INCIDENT_IO_API_KEY = "test-key"
-    process.env.SCHEDULE_ID = "schedule-123"
-    process.env.NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY = "7"
+    process.env.NEXT_ON_CALL_TARGET_WEEKDAY = "1"
+    process.env.NEXT_ON_CALL_TARGET_HOUR = "24"
 
     await expect(main()).rejects.toThrow(
-      'Invalid NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY: "7". Must be an integer between 0 and 6.'
+      'Invalid NEXT_ON_CALL_TARGET_HOUR: "24". Must be an integer between 0 and 23.'
     )
   })
 

--- a/scripts/on-call/next-on-call.test.ts
+++ b/scripts/on-call/next-on-call.test.ts
@@ -37,6 +37,16 @@ describe("buildPayload", () => {
 
     expect(payload.blocks[0].text.text).toContain("<@U_ALICE> looks like")
   })
+
+  it("posts a warning instead of an empty mention when there are no mentions", () => {
+    const payload = JSON.parse(buildPayload([], SCHEDULE_URL))
+
+    expect(payload.blocks).toHaveLength(1)
+    const text = payload.blocks[0].text.text
+    expect(text).toContain(":warning:")
+    expect(text).toContain("can't be reached on Slack")
+    expect(text).toContain(`<${SCHEDULE_URL}|on-call schedule>`)
+  })
 })
 
 describe("main", () => {
@@ -50,7 +60,7 @@ describe("main", () => {
       NEXT_ON_CALL_TARGET_WEEKDAY: "1",
       NEXT_ON_CALL_TARGET_HOUR: "11",
     }
-    mockNextOnCallUsers.mockResolvedValue([])
+    mockNextOnCallUsers.mockResolvedValue([{ id: "user-1" }])
     mockUsersToMentions.mockReturnValue(["<@U_ALICE>"])
     mockScheduleUrl.mockReturnValue(SCHEDULE_URL)
     mockNextShiftBoundaryInstant.mockReturnValue(WINDOW_END)
@@ -144,7 +154,7 @@ describe("main", () => {
     process.env.INCIDENT_IO_API_KEY = "test-key"
     process.env.SCHEDULE_ID = "schedule-123"
     process.env.GITHUB_OUTPUT = "/tmp/fake-output"
-    mockUsersToMentions.mockReturnValue([])
+    mockNextOnCallUsers.mockResolvedValue([])
     const consoleSpy = jest.spyOn(console, "log").mockImplementation()
 
     await main()
@@ -153,6 +163,26 @@ describe("main", () => {
       expect.stringContaining("skipping Slack notification")
     )
     expect(mockFs.appendFileSync).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+
+  it("still posts a warning payload when someone has an upcoming shift but no linked Slack account", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.GITHUB_OUTPUT = "/tmp/fake-output"
+    mockNextOnCallUsers.mockResolvedValue([{ id: "user-1" }])
+    mockUsersToMentions.mockReturnValue([])
+    mockFs.appendFileSync.mockImplementation(() => undefined)
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("skipping Slack notification")
+    )
+    expect(mockFs.appendFileSync).toHaveBeenCalledTimes(1)
+    const [, contents] = mockFs.appendFileSync.mock.calls[0]
+    expect(contents).toContain(":warning:")
     consoleSpy.mockRestore()
   })
 

--- a/scripts/on-call/next-on-call.test.ts
+++ b/scripts/on-call/next-on-call.test.ts
@@ -1,0 +1,203 @@
+import * as fs from "fs"
+import { nextOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
+import { buildPayload, main } from "./next-on-call"
+import { nextShiftBoundaryInstant, weekdayInTimeZone } from "./shift-boundary"
+
+jest.mock("fs")
+jest.mock("./incident-io")
+jest.mock("./shift-boundary")
+
+const mockFs = fs as jest.Mocked<typeof fs>
+const mockNextOnCallUsers = nextOnCallUsers as jest.Mock
+const mockUsersToMentions = usersToMentions as jest.Mock
+const mockScheduleUrl = scheduleUrl as jest.Mock
+const mockNextShiftBoundaryInstant = nextShiftBoundaryInstant as jest.Mock
+const mockWeekdayInTimeZone = weekdayInTimeZone as jest.Mock
+
+const WINDOW_END = new Date("2026-08-03T15:00:00Z")
+
+const SCHEDULE_URL =
+  "https://app.incident.io/artsy/on-call/schedules/schedule-123"
+
+describe("buildPayload", () => {
+  it("mentions everyone with an upcoming shift and links the schedule and incident handling doc", () => {
+    const payload = JSON.parse(
+      buildPayload(["<@U_ALICE>", "<@U_BOB>"], SCHEDULE_URL)
+    )
+
+    expect(payload.blocks).toHaveLength(1)
+    const text = payload.blocks[0].text.text
+    expect(text).toContain("<@U_ALICE>, <@U_BOB>")
+    expect(text).toContain("on-call shift coming up")
+    expect(text).toContain(`<${SCHEDULE_URL}|on-call schedule>`)
+    expect(text).toContain("Incident Handling doc")
+  })
+
+  it("handles a single mention", () => {
+    const payload = JSON.parse(buildPayload(["<@U_ALICE>"], SCHEDULE_URL))
+
+    expect(payload.blocks[0].text.text).toContain("<@U_ALICE> looks like")
+  })
+})
+
+describe("main", () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv, GITHUB_OUTPUT: undefined }
+    mockNextOnCallUsers.mockResolvedValue([])
+    mockUsersToMentions.mockReturnValue(["<@U_ALICE>"])
+    mockScheduleUrl.mockReturnValue(SCHEDULE_URL)
+    mockNextShiftBoundaryInstant.mockReturnValue(WINDOW_END)
+    mockWeekdayInTimeZone.mockReturnValue(1) // Monday by default
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it("throws when INCIDENT_IO_API_KEY is not set", async () => {
+    delete process.env.INCIDENT_IO_API_KEY
+    process.env.SCHEDULE_ID = "schedule-123"
+
+    await expect(main()).rejects.toThrow(
+      "INCIDENT_IO_API_KEY env var is not set."
+    )
+  })
+
+  it("throws when SCHEDULE_ID is not set", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    delete process.env.SCHEDULE_ID
+
+    await expect(main()).rejects.toThrow("SCHEDULE_ID env var is not set.")
+  })
+
+  it("on a Monday run, targets the Friday safety cutoff (default weekday 5, hour 0)", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    mockWeekdayInTimeZone.mockReturnValue(1)
+    jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(mockNextShiftBoundaryInstant).toHaveBeenCalledWith(
+      { weekday: 5, hour: 0 },
+      expect.any(Date)
+    )
+    expect(mockNextOnCallUsers).toHaveBeenCalledWith(
+      "test-key",
+      "schedule-123",
+      expect.any(Date),
+      WINDOW_END
+    )
+  })
+
+  it("on a Thursday run, targets the rot-na/sa rotation boundary (default weekday 1, hour 11)", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    mockWeekdayInTimeZone.mockReturnValue(4)
+    jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(mockNextShiftBoundaryInstant).toHaveBeenCalledWith(
+      { weekday: 1, hour: 11 },
+      expect.any(Date)
+    )
+  })
+
+  it("throws when run on a weekday other than Monday or Thursday", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    mockWeekdayInTimeZone.mockReturnValue(3) // Wednesday
+
+    await expect(main()).rejects.toThrow(
+      "expected to run on weekday 1 (Monday) or 4 (Thursday)"
+    )
+  })
+
+  it("respects NEXT_ON_CALL_RUN_WEEKDAY_OVERRIDE for testing on a different real day", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.NEXT_ON_CALL_RUN_WEEKDAY_OVERRIDE = "4"
+    mockWeekdayInTimeZone.mockReturnValue(3) // real day would otherwise throw
+    jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(mockNextShiftBoundaryInstant).toHaveBeenCalledWith(
+      { weekday: 1, hour: 11 },
+      expect.any(Date)
+    )
+  })
+
+  it("respects rotation/safety cutoff overrides", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY = "3"
+    process.env.NEXT_ON_CALL_ROTATION_BOUNDARY_HOUR = "9"
+    mockWeekdayInTimeZone.mockReturnValue(4)
+    jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(mockNextShiftBoundaryInstant).toHaveBeenCalledWith(
+      { weekday: 3, hour: 9 },
+      expect.any(Date)
+    )
+  })
+
+  it("throws when NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY is out of range", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY = "7"
+
+    await expect(main()).rejects.toThrow(
+      'Invalid NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY: "7". Must be an integer between 0 and 6.'
+    )
+  })
+
+  it("logs and skips without writing GITHUB_OUTPUT when no one has an upcoming shift", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.GITHUB_OUTPUT = "/tmp/fake-output"
+    mockUsersToMentions.mockReturnValue([])
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("skipping Slack notification")
+    )
+    expect(mockFs.appendFileSync).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+
+  it("logs the payload to stdout when GITHUB_OUTPUT is unset", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(consoleSpy.mock.calls[0][0]).toContain("<@U_ALICE>")
+    consoleSpy.mockRestore()
+  })
+
+  it("writes the payload to GITHUB_OUTPUT using the heredoc delimiter form", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.GITHUB_OUTPUT = "/tmp/fake-output"
+    mockFs.appendFileSync.mockImplementation(() => undefined)
+
+    await main()
+
+    expect(mockFs.appendFileSync).toHaveBeenCalledTimes(1)
+    const [outputPath, contents] = mockFs.appendFileSync.mock.calls[0]
+    expect(outputPath).toBe("/tmp/fake-output")
+    expect(contents).toMatch(/^payload<<EOF_\d+\n/)
+    expect(contents).toContain("<@U_ALICE>")
+  })
+})

--- a/scripts/on-call/next-on-call.ts
+++ b/scripts/on-call/next-on-call.ts
@@ -1,0 +1,165 @@
+import * as fs from "fs"
+
+import { nextOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
+import { nextShiftBoundaryInstant, weekdayInTimeZone } from "./shift-boundary"
+
+const DEFAULT_TIME_ZONE = "America/New_York"
+
+// Which weekday (0-6) the joule cron's two firings correspond to. These are
+// tied to the workflow's own cron schedule (`MON,THU`) rather than exposed as
+// inputs — changing which days this runs on would require code changes here
+// regardless (the target boundaries below are specific to the rotation
+// cadence, not just "whichever two days the cron happens to use").
+const MONDAY_RUN_WEEKDAY = 1
+const THURSDAY_RUN_WEEKDAY = 4
+
+// The rot-na/sa weekly handoff — the actual shift-change boundary. The
+// Thursday run targets this directly (tight, since it's the real boundary).
+const DEFAULT_ROTATION_BOUNDARY_WEEKDAY = 1 // Monday
+const DEFAULT_ROTATION_BOUNDARY_HOUR = 11 // 11am ET
+
+// A generous cutoff with no rotation significance of its own. The Monday run
+// targets this instead of the rot-eu/uk Wednesday boundary directly, so that
+// it still covers anything starting right up to (and a bit past) when the
+// Thursday run is due to fire, even if that run ends up delayed.
+const DEFAULT_SAFETY_CUTOFF_WEEKDAY = 5 // Friday
+const DEFAULT_SAFETY_CUTOFF_HOUR = 0 // midnight ET (start of Friday)
+
+const URLS = {
+  incidentHandling:
+    "https://app.notion.com/p/artsy/Incident-Handling-incident-io-edition-dcacab0764a08347addf015248667808#ceecab0764a082448dac814aa0c329d3",
+}
+
+export const buildPayload = (
+  mentions: string[],
+  onCallScheduleUrl: string
+): string => {
+  const text = `${mentions.join(
+    ", "
+  )} looks like you have an on-call shift coming up! Check out the <${
+    onCallScheduleUrl
+  }|on-call schedule> and the <${
+    URLS.incidentHandling
+  }|Incident Handling doc> to prep. You've got this! :+1:`
+
+  return JSON.stringify({
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text,
+        },
+      },
+    ],
+  })
+}
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} env var is not set.`)
+  }
+  return value
+}
+
+const readIntEnv = (
+  name: string,
+  defaultValue: number,
+  range: { min: number; max: number }
+): number => {
+  const raw = process.env[name]
+  const value = raw ? Number.parseInt(raw, 10) : defaultValue
+
+  if (Number.isNaN(value) || value < range.min || value > range.max) {
+    throw new Error(
+      `Invalid ${name}: "${raw}". Must be an integer between ${range.min} and ${range.max}.`
+    )
+  }
+
+  return value
+}
+
+export const main = async (): Promise<void> => {
+  const apiKey = requireEnv("INCIDENT_IO_API_KEY")
+  const scheduleId = requireEnv("SCHEDULE_ID")
+
+  const rotationBoundaryWeekday = readIntEnv(
+    "NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY",
+    DEFAULT_ROTATION_BOUNDARY_WEEKDAY,
+    { min: 0, max: 6 }
+  )
+  const rotationBoundaryHour = readIntEnv(
+    "NEXT_ON_CALL_ROTATION_BOUNDARY_HOUR",
+    DEFAULT_ROTATION_BOUNDARY_HOUR,
+    { min: 0, max: 23 }
+  )
+  const safetyCutoffWeekday = readIntEnv(
+    "NEXT_ON_CALL_SAFETY_CUTOFF_WEEKDAY",
+    DEFAULT_SAFETY_CUTOFF_WEEKDAY,
+    { min: 0, max: 6 }
+  )
+  const safetyCutoffHour = readIntEnv(
+    "NEXT_ON_CALL_SAFETY_CUTOFF_HOUR",
+    DEFAULT_SAFETY_CUTOFF_HOUR,
+    { min: 0, max: 23 }
+  )
+
+  const now = new Date()
+
+  // Overridable for local/manual testing on a day other than the real
+  // Monday/Thursday cron firings (mirrors STANDUP_BOUNDARY_WEEKDAY's role in
+  // standup-reminder.ts).
+  const runWeekday = readIntEnv(
+    "NEXT_ON_CALL_RUN_WEEKDAY_OVERRIDE",
+    weekdayInTimeZone(DEFAULT_TIME_ZONE, now),
+    { min: 0, max: 6 }
+  )
+
+  let windowEnd: Date
+  if (runWeekday === MONDAY_RUN_WEEKDAY) {
+    windowEnd = nextShiftBoundaryInstant(
+      { weekday: safetyCutoffWeekday, hour: safetyCutoffHour },
+      now
+    )
+  } else if (runWeekday === THURSDAY_RUN_WEEKDAY) {
+    windowEnd = nextShiftBoundaryInstant(
+      { weekday: rotationBoundaryWeekday, hour: rotationBoundaryHour },
+      now
+    )
+  } else {
+    throw new Error(
+      `next-on-call expected to run on weekday ${MONDAY_RUN_WEEKDAY} (Monday) or ${THURSDAY_RUN_WEEKDAY} (Thursday) in ${DEFAULT_TIME_ZONE}, but it's ${runWeekday}. Set NEXT_ON_CALL_RUN_WEEKDAY_OVERRIDE to test on a different day.`
+    )
+  }
+
+  const users = await nextOnCallUsers(apiKey, scheduleId, now, windowEnd)
+  const mentions = usersToMentions(users)
+
+  if (mentions.length === 0) {
+    console.log(
+      "next-on-call: no upcoming shifts starting in this window — skipping Slack notification."
+    )
+    return
+  }
+
+  const payload = buildPayload(mentions, scheduleUrl(scheduleId))
+
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (outputPath) {
+    const delimiter = `EOF_${Date.now()}`
+    fs.appendFileSync(
+      outputPath,
+      `payload<<${delimiter}\n${payload}\n${delimiter}\n`
+    )
+  } else {
+    console.log(payload)
+  }
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/scripts/on-call/next-on-call.ts
+++ b/scripts/on-call/next-on-call.ts
@@ -12,13 +12,22 @@ export const buildPayload = (
   mentions: string[],
   onCallScheduleUrl: string
 ): string => {
-  const text = `${mentions.join(
-    ", "
-  )} looks like you have an on-call shift coming up! Check out the <${
-    onCallScheduleUrl
-  }|on-call schedule> and the <${
-    URLS.incidentHandling
-  }|Incident Handling doc> to prep. You've got this! :+1:`
+  // mentions can legitimately be empty even when someone does have a shift
+  // starting soon — usersToMentions drops anyone without a linked Slack
+  // account (incident.io supports SAML SSO and Microsoft Teams as
+  // alternatives to Slack, so this isn't just a hypothetical). Warn instead
+  // of staying silent, so a missing Slack link surfaces rather than swallows
+  // the reminder entirely.
+  const text =
+    mentions.length > 0
+      ? `${mentions.join(
+          ", "
+        )} looks like you have an on-call shift coming up! Check out the <${
+          onCallScheduleUrl
+        }|on-call schedule> and the <${
+          URLS.incidentHandling
+        }|Incident Handling doc> to prep. You've got this! :+1:`
+      : `:warning: Heads up — someone's on-call shift is starting soon, but they can't be reached on Slack (no linked account). Check the <${onCallScheduleUrl}|on-call schedule>.`
 
   return JSON.stringify({
     blocks: [
@@ -83,15 +92,15 @@ export const main = async (): Promise<void> => {
   )
 
   const users = await nextOnCallUsers(apiKey, scheduleId, now, windowEnd)
-  const mentions = usersToMentions(users)
 
-  if (mentions.length === 0) {
+  if (users.length === 0) {
     console.log(
       "next-on-call: no upcoming shifts starting in this window — skipping Slack notification."
     )
     return
   }
 
+  const mentions = usersToMentions(users)
   const payload = buildPayload(mentions, scheduleUrl(scheduleId))
 
   const outputPath = process.env.GITHUB_OUTPUT

--- a/scripts/on-call/next-on-call.ts
+++ b/scripts/on-call/next-on-call.ts
@@ -1,29 +1,7 @@
 import * as fs from "fs"
 
 import { nextOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
-import { nextShiftBoundaryInstant, weekdayInTimeZone } from "./shift-boundary"
-
-const DEFAULT_TIME_ZONE = "America/New_York"
-
-// Which weekday (0-6) the joule cron's two firings correspond to. These are
-// tied to the workflow's own cron schedule (`MON,THU`) rather than exposed as
-// inputs — changing which days this runs on would require code changes here
-// regardless (the target boundaries below are specific to the rotation
-// cadence, not just "whichever two days the cron happens to use").
-const MONDAY_RUN_WEEKDAY = 1
-const THURSDAY_RUN_WEEKDAY = 4
-
-// The rot-na/sa weekly handoff — the actual shift-change boundary. The
-// Thursday run targets this directly (tight, since it's the real boundary).
-const DEFAULT_ROTATION_BOUNDARY_WEEKDAY = 1 // Monday
-const DEFAULT_ROTATION_BOUNDARY_HOUR = 11 // 11am ET
-
-// A generous cutoff with no rotation significance of its own. The Monday run
-// targets this instead of the rot-eu/uk Wednesday boundary directly, so that
-// it still covers anything starting right up to (and a bit past) when the
-// Thursday run is due to fire, even if that run ends up delayed.
-const DEFAULT_SAFETY_CUTOFF_WEEKDAY = 5 // Friday
-const DEFAULT_SAFETY_CUTOFF_HOUR = 0 // midnight ET (start of Friday)
+import { nextShiftBoundaryInstant } from "./shift-boundary"
 
 const URLS = {
   incidentHandling:
@@ -63,13 +41,12 @@ const requireEnv = (name: string): string => {
   return value
 }
 
-const readIntEnv = (
+const requireIntEnv = (
   name: string,
-  defaultValue: number,
   range: { min: number; max: number }
 ): number => {
-  const raw = process.env[name]
-  const value = raw ? Number.parseInt(raw, 10) : defaultValue
+  const raw = requireEnv(name)
+  const value = Number.parseInt(raw, 10)
 
   if (Number.isNaN(value) || value < range.min || value > range.max) {
     throw new Error(
@@ -84,54 +61,26 @@ export const main = async (): Promise<void> => {
   const apiKey = requireEnv("INCIDENT_IO_API_KEY")
   const scheduleId = requireEnv("SCHEDULE_ID")
 
-  const rotationBoundaryWeekday = readIntEnv(
-    "NEXT_ON_CALL_ROTATION_BOUNDARY_WEEKDAY",
-    DEFAULT_ROTATION_BOUNDARY_WEEKDAY,
-    { min: 0, max: 6 }
-  )
-  const rotationBoundaryHour = readIntEnv(
-    "NEXT_ON_CALL_ROTATION_BOUNDARY_HOUR",
-    DEFAULT_ROTATION_BOUNDARY_HOUR,
-    { min: 0, max: 23 }
-  )
-  const safetyCutoffWeekday = readIntEnv(
-    "NEXT_ON_CALL_SAFETY_CUTOFF_WEEKDAY",
-    DEFAULT_SAFETY_CUTOFF_WEEKDAY,
-    { min: 0, max: 6 }
-  )
-  const safetyCutoffHour = readIntEnv(
-    "NEXT_ON_CALL_SAFETY_CUTOFF_HOUR",
-    DEFAULT_SAFETY_CUTOFF_HOUR,
-    { min: 0, max: 23 }
-  )
+  // The caller — one job per cron day — supplies its own literal target.
+  // E.g. the Thursday job passes the real rot-na/sa boundary (Monday, 11am
+  // ET) tightly; the Monday job passes a generous safety cutoff (Friday,
+  // midnight ET) with no rotation significance of its own, so a delayed
+  // Thursday run is still covered. This script doesn't need to know which
+  // is which, or which day it's actually running on.
+  const targetWeekday = requireIntEnv("NEXT_ON_CALL_TARGET_WEEKDAY", {
+    min: 0,
+    max: 6,
+  })
+  const targetHour = requireIntEnv("NEXT_ON_CALL_TARGET_HOUR", {
+    min: 0,
+    max: 23,
+  })
 
   const now = new Date()
-
-  // Overridable for local/manual testing on a day other than the real
-  // Monday/Thursday cron firings (mirrors STANDUP_BOUNDARY_WEEKDAY's role in
-  // standup-reminder.ts).
-  const runWeekday = readIntEnv(
-    "NEXT_ON_CALL_RUN_WEEKDAY_OVERRIDE",
-    weekdayInTimeZone(DEFAULT_TIME_ZONE, now),
-    { min: 0, max: 6 }
+  const windowEnd = nextShiftBoundaryInstant(
+    { weekday: targetWeekday, hour: targetHour },
+    now
   )
-
-  let windowEnd: Date
-  if (runWeekday === MONDAY_RUN_WEEKDAY) {
-    windowEnd = nextShiftBoundaryInstant(
-      { weekday: safetyCutoffWeekday, hour: safetyCutoffHour },
-      now
-    )
-  } else if (runWeekday === THURSDAY_RUN_WEEKDAY) {
-    windowEnd = nextShiftBoundaryInstant(
-      { weekday: rotationBoundaryWeekday, hour: rotationBoundaryHour },
-      now
-    )
-  } else {
-    throw new Error(
-      `next-on-call expected to run on weekday ${MONDAY_RUN_WEEKDAY} (Monday) or ${THURSDAY_RUN_WEEKDAY} (Thursday) in ${DEFAULT_TIME_ZONE}, but it's ${runWeekday}. Set NEXT_ON_CALL_RUN_WEEKDAY_OVERRIDE to test on a different day.`
-    )
-  }
 
   const users = await nextOnCallUsers(apiKey, scheduleId, now, windowEnd)
   const mentions = usersToMentions(users)

--- a/scripts/on-call/shift-boundary.test.ts
+++ b/scripts/on-call/shift-boundary.test.ts
@@ -1,4 +1,8 @@
-import { shiftBoundaryAnchor } from "./shift-boundary"
+import {
+  nextShiftBoundaryInstant,
+  shiftBoundaryAnchor,
+  weekdayInTimeZone,
+} from "./shift-boundary"
 
 describe("shiftBoundaryAnchor", () => {
   it("anchors 1 second before the boundary during EDT (UTC-4)", () => {
@@ -48,5 +52,81 @@ describe("shiftBoundaryAnchor", () => {
     )
 
     expect(anchor.toISOString()).toBe("2026-07-13T05:29:59.000Z")
+  })
+})
+
+describe("weekdayInTimeZone", () => {
+  it("returns the weekday as observed in the given timezone", () => {
+    // Monday 2026-07-27, 11:00am EDT -> 2026-07-27T15:00:00Z
+    const now = new Date("2026-07-27T15:00:00Z")
+
+    expect(weekdayInTimeZone("America/New_York", now)).toBe(1)
+  })
+
+  it("differs from the UTC calendar day when they straddle midnight ET", () => {
+    // 2026-07-28T02:00:00Z is Tuesday in UTC, but 10:00pm Monday in EDT.
+    const now = new Date("2026-07-28T02:00:00Z")
+
+    expect(now.getUTCDay()).toBe(2) // Tuesday, naive UTC day
+    expect(weekdayInTimeZone("America/New_York", now)).toBe(1) // Monday, ET
+  })
+})
+
+describe("nextShiftBoundaryInstant", () => {
+  it("returns today's boundary when its hour hasn't passed yet", () => {
+    // Monday 2026-07-27, 10:00am EDT -- boundary is 11am ET, later today.
+    const now = new Date("2026-07-27T14:00:00Z")
+
+    const instant = nextShiftBoundaryInstant({ weekday: 1, hour: 11 }, now)
+
+    expect(instant.toISOString()).toBe("2026-07-27T15:00:00.000Z")
+  })
+
+  it("rolls forward a full week when today's boundary hour already passed", () => {
+    // Monday 2026-07-27, 12:00pm EDT -- boundary (11am ET) already passed.
+    const now = new Date("2026-07-27T16:00:00Z")
+
+    const instant = nextShiftBoundaryInstant({ weekday: 1, hour: 11 }, now)
+
+    expect(instant.toISOString()).toBe("2026-08-03T15:00:00.000Z")
+  })
+
+  it("projects forward to a later weekday within the same week", () => {
+    // Thursday 2026-07-30, 11:00am EDT -> next Monday 11am ET boundary.
+    // Matches real schedule_entries data validated against production.
+    const now = new Date("2026-07-30T15:00:00Z")
+
+    const instant = nextShiftBoundaryInstant({ weekday: 1, hour: 11 }, now)
+
+    expect(instant.toISOString()).toBe("2026-08-03T15:00:00.000Z")
+  })
+
+  it("projects forward to Friday midnight ET from a Monday", () => {
+    // Monday 2026-07-27, 11:00am EDT -> Friday 2026-07-31, midnight ET.
+    const now = new Date("2026-07-27T15:00:00Z")
+
+    const instant = nextShiftBoundaryInstant({ weekday: 5, hour: 0 }, now)
+
+    expect(instant.toISOString()).toBe("2026-07-31T04:00:00.000Z")
+  })
+
+  it("resolves the offset for the target date, not now's date, across a DST fall-back", () => {
+    // Thursday 2026-10-29 is EDT (UTC-4); the next Monday, 2026-11-02, is
+    // after the Nov 1 fall-back and is EST (UTC-5).
+    const now = new Date("2026-10-29T15:00:00Z")
+
+    const instant = nextShiftBoundaryInstant({ weekday: 1, hour: 11 }, now)
+
+    expect(instant.toISOString()).toBe("2026-11-02T16:00:00.000Z")
+  })
+
+  it("rolls across a year boundary correctly", () => {
+    // Monday 2026-12-28, 12:30pm EST -- boundary (11am ET) already passed;
+    // next Monday is 2027-01-04.
+    const now = new Date("2026-12-28T17:30:00Z")
+
+    const instant = nextShiftBoundaryInstant({ weekday: 1, hour: 11 }, now)
+
+    expect(instant.toISOString()).toBe("2027-01-04T16:00:00.000Z")
   })
 })

--- a/scripts/on-call/shift-boundary.test.ts
+++ b/scripts/on-call/shift-boundary.test.ts
@@ -1,8 +1,4 @@
-import {
-  nextShiftBoundaryInstant,
-  shiftBoundaryAnchor,
-  weekdayInTimeZone,
-} from "./shift-boundary"
+import { nextShiftBoundaryInstant, shiftBoundaryAnchor } from "./shift-boundary"
 
 describe("shiftBoundaryAnchor", () => {
   it("anchors 1 second before the boundary during EDT (UTC-4)", () => {
@@ -52,23 +48,6 @@ describe("shiftBoundaryAnchor", () => {
     )
 
     expect(anchor.toISOString()).toBe("2026-07-13T05:29:59.000Z")
-  })
-})
-
-describe("weekdayInTimeZone", () => {
-  it("returns the weekday as observed in the given timezone", () => {
-    // Monday 2026-07-27, 11:00am EDT -> 2026-07-27T15:00:00Z
-    const now = new Date("2026-07-27T15:00:00Z")
-
-    expect(weekdayInTimeZone("America/New_York", now)).toBe(1)
-  })
-
-  it("differs from the UTC calendar day when they straddle midnight ET", () => {
-    // 2026-07-28T02:00:00Z is Tuesday in UTC, but 10:00pm Monday in EDT.
-    const now = new Date("2026-07-28T02:00:00Z")
-
-    expect(now.getUTCDay()).toBe(2) // Tuesday, naive UTC day
-    expect(weekdayInTimeZone("America/New_York", now)).toBe(1) // Monday, ET
   })
 })
 

--- a/scripts/on-call/shift-boundary.ts
+++ b/scripts/on-call/shift-boundary.ts
@@ -1,8 +1,10 @@
-// Anchors "who was on-call as of a shift-change boundary" to a fixed instant
-// derived from that boundary's calendar day, rather than the literal
-// execution time of the caller. GitHub's `schedule` trigger can fire a few
-// minutes late; without this, a late-firing job could cross the boundary and
-// pick up the incoming shift instead of the outgoing one it's meant to report.
+// Computes deterministic instants around on-call shift-change boundaries,
+// independent of the caller's literal execution time (GitHub's `schedule`
+// trigger can fire a few minutes late). `shiftBoundaryAnchor` looks
+// backward — "who was on-call as of this boundary" — so a late-firing job
+// doesn't cross into the incoming shift. `nextShiftBoundaryInstant` looks
+// forward — "when does the next occurrence of this boundary happen" — for
+// callers that need to search ahead rather than pin down "now."
 //
 // Boundaries are defined in local wall-clock time (e.g. "11am ET"), but the
 // API this feeds only understands UTC instants, so this file also converts
@@ -142,4 +144,69 @@ export const shiftBoundaryAnchor = (
   )
 
   return new Date(boundaryInstant.getTime() - BOUNDARY_SAFETY_MARGIN_MS)
+}
+
+// Returns `now`'s weekday (0-6, Date#getDay convention) as observed in
+// `timeZone` — e.g. so a caller can branch on "which day is this in ET"
+// without relying on `now.getDay()`, which reflects the runtime's local
+// timezone (or UTC in most CI environments), not the intended one.
+export const weekdayInTimeZone = (timeZone: string, now: Date): number =>
+  civilDateTimeIn(timeZone, now).weekday
+
+// Reads a civil (year, month, day) plus a day offset and returns the civil
+// date that many days later, resolved through a fixed mid-day UTC instant so
+// month/year rollovers are handled by `Date.UTC`'s normal overflow behavior,
+// and the DST offset lookup never lands near a transition's own boundary
+// hour (see `zonedTimeToUtc`'s caveat above).
+const civilDatePlusDays = (
+  timeZone: string,
+  civil: Pick<CivilDateTime, "year" | "month" | "day">,
+  days: number
+): CivilDateTime =>
+  civilDateTimeIn(
+    timeZone,
+    new Date(Date.UTC(civil.year, civil.month - 1, civil.day + days, 12))
+  )
+
+// Finds the next occurrence (today or later, up to 7 days out) of a
+// weekday+hour boundary that is strictly after `now` — unlike
+// `shiftBoundaryAnchor`, this never throws: if `now` isn't already on the
+// target weekday, or today's occurrence of the target hour has already
+// passed, it rolls forward to the next matching day instead. Used to compute
+// how far ahead a forward-looking lookup (e.g. "next on-call") should search,
+// where the caller doesn't necessarily run on the boundary day itself.
+export const nextShiftBoundaryInstant = (
+  boundary: ShiftBoundary,
+  now: Date = new Date()
+): Date => {
+  const timeZone = boundary.timeZone ?? DEFAULT_TIME_ZONE
+  const civil = civilDateTimeIn(timeZone, now)
+
+  const daysUntilWeekday = (boundary.weekday - civil.weekday + 7) % 7
+  const candidate = civilDatePlusDays(timeZone, civil, daysUntilWeekday)
+
+  const instant = zonedTimeToUtc(
+    candidate.year,
+    candidate.month,
+    candidate.day,
+    boundary.hour,
+    0,
+    0,
+    timeZone
+  )
+
+  if (instant.getTime() > now.getTime()) {
+    return instant
+  }
+
+  const nextWeek = civilDatePlusDays(timeZone, candidate, 7)
+  return zonedTimeToUtc(
+    nextWeek.year,
+    nextWeek.month,
+    nextWeek.day,
+    boundary.hour,
+    0,
+    0,
+    timeZone
+  )
 }

--- a/scripts/on-call/shift-boundary.ts
+++ b/scripts/on-call/shift-boundary.ts
@@ -146,13 +146,6 @@ export const shiftBoundaryAnchor = (
   return new Date(boundaryInstant.getTime() - BOUNDARY_SAFETY_MARGIN_MS)
 }
 
-// Returns `now`'s weekday (0-6, Date#getDay convention) as observed in
-// `timeZone` — e.g. so a caller can branch on "which day is this in ET"
-// without relying on `now.getDay()`, which reflects the runtime's local
-// timezone (or UTC in most CI environments), not the intended one.
-export const weekdayInTimeZone = (timeZone: string, now: Date): number =>
-  civilDateTimeIn(timeZone, now).weekday
-
 // Reads a civil (year, month, day) plus a day offset and returns the civil
 // date that many days later, resolved through a fixed mid-day UTC instant so
 // month/year rollovers are handled by `Date.UTC`'s normal overflow behavior,


### PR DESCRIPTION
## Summary
- Adds `nextOnCallUsers` (`incident-io.ts`) and `nextShiftBoundaryInstant` (`shift-boundary.ts`) to derive upcoming on-call shifts from incident.io's `/v2/schedule_entries` — incident.io has no dedicated "next on-call" endpoint (Opsgenie did), so this is derived client-side
- New reusable workflow `incident-next-on-call.yml`: takes `schedule-id`, `target-weekday`, `target-hour` (all required) and posts a Slack heads-up to engineers whose shift hasn't started yet; silently skips (no Slack post) when nothing is upcoming
- Meant to be called once per cron schedule the caller runs, each call passing its own literal target weekday/hour — see `docs/actions.md` for the two-job calling pattern this is designed around

## Test plan
- [x] `yarn jest scripts/on-call` — 45 tests passing
- [x] `yarn biome check` clean
- [x] Verified against real incident.io schedule data via manual curl requests and local `ts-node` runs

Assisted-by: Claude:Sonnet-5 [Claude Code]