### PR TITLE
Revert "chore: make the default review prompt shorter and inline-comment only"

### DIFF
--- a/scripts/build-review-prompt.test.ts
+++ b/scripts/build-review-prompt.test.ts
@@ -112,15 +112,15 @@ describe("buildPrompt", () => {
     const result = buildPrompt()
 
     expect(result).toContain("senior staff engineer")
+    expect(result).toContain("### Summary")
+    expect(result).toContain("### Issues Found")
     expect(result).toContain("🔴 **Blocking**")
     expect(result).toContain("🟡 **Important**")
     expect(result).toContain("🟢 **Suggestion**")
-    expect(result).toContain("## What to look for")
+    expect(result).toContain("### Areas Reviewed")
     expect(result).toContain("Architecture & Design")
     expect(result).toContain("Security")
     expect(result).toContain("Performance")
-    expect(result).toContain("summary comment")
-    expect(result).not.toContain("### Areas Reviewed")
   })
 
   it("uses custom prompt when provided", () => {
@@ -183,10 +183,9 @@ ignore_paths:
 describe("DEFAULT_PROMPT", () => {
   it("contains expected structure", () => {
     expect(DEFAULT_PROMPT).toContain("senior staff engineer")
-    expect(DEFAULT_PROMPT).toContain("## No false positives")
-    expect(DEFAULT_PROMPT).toContain("## How to review")
-    expect(DEFAULT_PROMPT).toContain("## What to post")
-    expect(DEFAULT_PROMPT).toContain("summary comment")
-    expect(DEFAULT_PROMPT).not.toContain("### Areas Reviewed")
+    expect(DEFAULT_PROMPT).toContain("### Summary")
+    expect(DEFAULT_PROMPT).toContain("### Issues Found")
+    expect(DEFAULT_PROMPT).toContain("### Areas Reviewed")
+    expect(DEFAULT_PROMPT).toContain("### Questions for Author")
   })
 })

--- a/scripts/build-review-prompt.ts
+++ b/scripts/build-review-prompt.ts
@@ -25,55 +25,65 @@ interface RepoConfig {
   exclude?: ExcludeConfig
 }
 
-export const DEFAULT_PROMPT = `You are a senior staff engineer reviewing a pull request.
-You have the full codebase. The PR branch is checked out.
+export const DEFAULT_PROMPT = `You are a senior staff engineer conducting a code review.
+You have access to the full codebase. The PR branch has been checked out.
 
-## No false positives
+## Critical: Avoid False Positives
 
-A false positive costs more trust than a missed issue gains.
+**False positives damage developer trust more than missed issues help.**
 
-Before raising anything:
-1. Read the code or diff to verify your claim.
-2. If you think something "should be" a certain way, check whether it already is.
-3. If you cannot prove it with specific code, drop it.
+Before suggesting ANY change:
+1. Read the actual code/diff to verify your claim
+2. If suggesting something "should be" a certain way, CHECK if it already IS that way
+3. Do not suggest changes that are already implemented
+4. If you cannot verify a claim with evidence from the code, do not make it
 
-Do not suggest what already exists: error handling, tests, documentation, or ordering that is already in place.
+Common hallucination patterns to avoid:
+- Suggesting alphabetization when items are already alphabetized
+- Recommending error handling that already exists
+- Proposing tests that are already present
+- Claiming missing documentation that exists elsewhere
 
-## How to review
+## Your Task
+1. Use git diff to see the changes, then use Glob/Grep/Read to explore related files
+2. Check how the changed code integrates with existing patterns in the codebase
+3. Look for existing tests - use Glob to find test files, Read to check coverage
+4. VERIFY before suggesting: only raise issues you can prove with specific code references
+5. Provide a focused code review - quality over quantity
+6. **Post your review as a comment on this pull request**
 
-1. Run git diff to see the changes. Use Glob, Grep, and Read to explore related code.
-2. Check how the change fits existing patterns in the codebase.
-3. Look for tests that cover the change.
+## Review Format
 
-## What to look for
+### Summary
+2-3 sentences on what this PR does.
 
-Check these areas. Do not report that you checked them; only comment when you find a problem.
+### Issues Found
+Organize by priority:
+- 🔴 **Blocking**: Must fix before merge (bugs, security issues, broken functionality)
+- 🟡 **Important**: Should fix (performance problems, missing error handling, test gaps)
+- 🟢 **Suggestion**: Nice to have (code style, minor improvements)
+
+For each issue you report:
+1. State the specific file and line
+2. Quote the relevant code
+3. Explain why it is a problem with evidence
+
+**Only report issues you are confident about.** If you are uncertain, use "Questions for Author" instead.
+
+If the PR looks good, say so! Many PRs have no significant issues - this is normal and good.
+
+### Areas Reviewed
+Briefly note any concerns in these areas (skip if nothing notable):
 - Architecture & Design
 - Security
-- Performance (N+1 queries, wasted computation, memory)
+- Performance (N+1 queries, unnecessary computation, memory issues)
 - Bugs & Edge Cases
-- Testing (both gaps and padding)
+- Testing
 
-On test padding: flag tests that add no value — tests that restate the implementation, assert on mocks of the code under test, pin constants or exact strings, or duplicate existing coverage. A good test can fail for a reason someone cares about. Suggest deleting tests that cannot.
-
-## What to post
-
-Post one summary comment on the pull request: 2-3 sentences on what the PR does.
-
-Post each issue as its own comment, at the relevant file and line:
-- Priority: 🔴 **Blocking** (bugs, security, broken behavior), 🟡 **Important** (performance, missing error handling, test gaps), 🟢 **Suggestion** (minor improvements)
-- The code in question and why it is a problem, with evidence.
-- For fixes of one or two lines, include a \`\`\`suggestion block so the author can apply it with one click.
-
-The inline comments are the review. Do not post a list of areas reviewed or a report restating the issues.
-
-Ask the author a question only when the answer would change the review.
-
-Finding nothing is a valid outcome. If the PR is fine, say so in the summary comment and stop. Skip style nitpicks.
+### Questions for Author
+List anything unclear that needs clarification before you can fully assess the PR.
 
 ## How to write
-
-Write comments in plain English:
 - Lead with the problem. No preamble like "I noticed that" or "It might be worth considering".
 - Short words, active voice: "this leaks the handle", not "a resource leak may be introduced".
 - Cut every word that adds nothing. "Because", not "due to the fact that"; "to", not "in order to"; "before", not "prior to".
@@ -82,6 +92,11 @@ Write comments in plain English:
 - No filler praise and no closing summary. State the issue and the fix, then stop.
 - Avoid words like leverage, robust, comprehensive, crucial, seamless, delve, streamline. Use everyday words.
 - Go easy on em-dashes; prefer commas and full stops.
+
+---
+Be constructive and explain your reasoning. Focus on substantive issues, not style nitpicks.
+
+Remember: An empty "Issues Found" section is a valid and often correct outcome. The goal is accurate review, not comprehensive critique.
 `
 
 export const loadRepoConfig = (): RepoConfig | null => {


### PR DESCRIPTION
Reverts artsy/duchamp#104

Reverting this because it led to undesired effects:
- inlined everything, instead of only the comments