### PR TITLE
feat: add facilitate-incident-review on-call notifier

### DIFF
--- a/.github/workflows/incident-facilitate-review.yml
+++ b/.github/workflows/incident-facilitate-review.yml
@@ -31,13 +31,14 @@ on:
         default: 30
         required: false
         type: number
-      lookahead-days:
-        description: "Days ahead of the run to search for a qualifying meeting date. A routine day-before cron only needs 1; an occasional manual catch-up trigger needs enough slack to reach an off-week exception date on any weekday (e.g. 6, to cover a Friday trigger for the following Monday)."
+      base-date:
+        description: "YYYY-MM-DD date known to fall on a biweekly on-week — anchors the every-other-week Incident Review cadence. Must fall on the same weekday as meeting-weekday"
         required: true
-        type: number
-      dates:
-        description: 'JSON { baseDate: string, exceptions: string[] } — biweekly cadence anchor and any catch-up override dates (each a YYYY-MM-DD meeting date)'
-        required: true
+        type: string
+      override-date:
+        description: "YYYY-MM-DD to target directly, bypassing the on/off-week check — for a rare manual catch-up review on an off-week or non-standard weekday. Leave unset for the routine day-before cron run"
+        required: false
+        default: ""
         type: string
 
 jobs:
@@ -76,8 +77,8 @@ jobs:
           MEETING_WEEKDAY: ${{ inputs.meeting-weekday }}
           MEETING_HOUR: ${{ inputs.meeting-hour }}
           MEETING_MINUTE: ${{ inputs.meeting-minute }}
-          MEETING_LOOKAHEAD_DAYS: ${{ inputs.lookahead-days }}
-          DATES: ${{ inputs.dates }}
+          MEETING_BASE_DATE: ${{ inputs.base-date }}
+          MEETING_OVERRIDE_DATE: ${{ inputs.override-date }}
 
       - name: Facilitate Review > Slack
         if: steps.cli.outputs.payload != ''

--- a/.github/workflows/incident-facilitate-review.yml
+++ b/.github/workflows/incident-facilitate-review.yml
@@ -1,0 +1,89 @@
+name: Incident.io Facilitate Review
+
+on:
+  workflow_call:
+    secrets:
+      incident-io-api-key:
+        required: true
+      slack-webhook-url:
+        required: true
+    inputs:
+      schedule-id:
+        description: "incident.io schedule ID for the Engineering on-call schedule"
+        required: true
+        type: string
+      node-version:
+        default: "22"
+        required: false
+        type: string
+      meeting-weekday:
+        description: "Weekday the Incident Review meeting itself runs, 0 (Sun) - 6 (Sat). Default: 4 (Thursday)"
+        default: 4
+        required: false
+        type: number
+      meeting-hour:
+        description: "Hour the meeting runs, 0-23, America/New_York time. Default: 11 (11:30am ET)"
+        default: 11
+        required: false
+        type: number
+      meeting-minute:
+        description: "Minute the meeting runs, 0-59. Default: 30 (11:30am ET)"
+        default: 30
+        required: false
+        type: number
+      lookahead-days:
+        description: "Days ahead of the run to search for a qualifying meeting date. A routine day-before cron only needs 1; an occasional manual catch-up trigger needs enough slack to reach an off-week exception date on any weekday (e.g. 6, to cover a Friday trigger for the following Monday)."
+        required: true
+        type: number
+      dates:
+        description: 'JSON { baseDate: string, exceptions: string[] } — biweekly cadence anchor and any catch-up override dates (each a YYYY-MM-DD meeting date)'
+        required: true
+        type: string
+
+jobs:
+  facilitate-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout tooling repo
+        uses: actions/checkout@v4
+        with:
+          repository: artsy/duchamp
+          ref: main
+          path: .tooling
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install tooling dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: .tooling
+        env:
+          YARN_IGNORE_PATH: 1
+
+      - name: Run facilitate incident review
+        id: cli
+        run: .tooling/node_modules/.bin/ts-node .tooling/scripts/on-call/facilitate-incident-review.ts
+        env:
+          INCIDENT_IO_API_KEY: ${{ secrets.incident-io-api-key }}
+          SCHEDULE_ID: ${{ inputs.schedule-id }}
+          MEETING_WEEKDAY: ${{ inputs.meeting-weekday }}
+          MEETING_HOUR: ${{ inputs.meeting-hour }}
+          MEETING_MINUTE: ${{ inputs.meeting-minute }}
+          MEETING_LOOKAHEAD_DAYS: ${{ inputs.lookahead-days }}
+          DATES: ${{ inputs.dates }}
+
+      - name: Facilitate Review > Slack
+        if: steps.cli.outputs.payload != ''
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: ${{ steps.cli.outputs.payload }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}

--- a/.github/workflows/incident-facilitate-review.yml
+++ b/.github/workflows/incident-facilitate-review.yml
@@ -16,21 +16,29 @@ on:
         default: "22"
         required: false
         type: string
+      # type: string, not number -- a caller passing an unset vars.* through
+      # here (e.g. ${{ vars.MEETING_HOUR }}) needs the empty-value case to
+      # stay an empty string. A type: number input coerces that same empty
+      # value to a literal 0 instead of this declared default (a real
+      # GitHub Actions behavior, not a hypothetical), and readIntEnv's
+      # falsy check can't tell "0" the string apart from a real 0 once it
+      # reaches the script's env — the fix has to happen at this type
+      # declaration, not in the script.
       meeting-weekday:
         description: "Weekday the Incident Review meeting itself runs, 0 (Sun) - 6 (Sat). Default: 4 (Thursday)"
-        default: 4
+        default: "4"
         required: false
-        type: number
+        type: string
       meeting-hour:
         description: "Hour the meeting runs, 0-23, America/New_York time. Default: 11 (11:30am ET)"
-        default: 11
+        default: "11"
         required: false
-        type: number
+        type: string
       meeting-minute:
         description: "Minute the meeting runs, 0-59. Default: 30 (11:30am ET)"
-        default: 30
+        default: "30"
         required: false
-        type: number
+        type: string
       base-date:
         description: "YYYY-MM-DD date known to fall on a biweekly on-week — anchors the every-other-week Incident Review cadence. Must fall on the same weekday as meeting-weekday"
         required: true

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -513,7 +513,7 @@ joule's real workflow sources these values from repo vars instead of literals, s
 - Manual catch-up path (`override-date` set): targets that date directly, on any weekday, bypassing the on/off-week check entirely — meant to be filled in at `workflow_dispatch` trigger time for a rare off-week catch-up review
 - Incident Reviews run every other week: `base-date` anchors that cadence — a date known to fall on an on-week, with parity alternating every 7 days via exact day-level integer arithmetic (never drifts, no matter how old `base-date` gets)
 - Picks one random participant from whoever is actually on-call at the resolved meeting instant (naturally covers however many rotations the schedule has, not hardcoded to a specific count)
-- Posts an explicit `:warning:` notice instead of a silent/empty mention if nobody on-call can be reached on Slack (no linked account)
+- Posts an explicit `:warning:` notice instead of a silent/empty mention when nobody on-call is reachable on Slack — whether that's a schedule gap or on-call participants with no linked Slack account
 - Silently skips posting to Slack (logs to the run's console output instead) when the routine path lands on a legitimate off-week
 
 **Inputs:**

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -15,6 +15,7 @@ This document provides detailed reference information for all GitHub Actions ava
 | `link-pr-to-notion.yml`             | Link PRs to Notion tasks       | For repos using Notion task tracking |
 | `incident-standup-reminder.yml`      | Remind on-call to run standup  | For scheduled Slack standup reminders |
 | `incident-next-on-call.yml`          | Remind engineers of an upcoming on-call shift | For scheduled Slack next-on-call reminders |
+| `incident-facilitate-review.yml`     | Pick a random facilitator for the Incident Review | For scheduled Slack Incident Review facilitator selection |
 
 ## Action Reference
 
@@ -471,6 +472,63 @@ The specific values above reflect one real cadence (a generous Friday-midnight c
 
 ---
 
+### incident-facilitate-review.yml
+
+**Purpose**: Post a Slack notice picking a random on-call participant to facilitate the upcoming Incident Review meeting
+
+**Use Case**: Scheduled workflows that need to select and notify a facilitator ahead of a biweekly Incident Review meeting, sourced from an incident.io schedule. Intended to be called from both a routine day-before cron and an occasional manual `workflow_dispatch` for off-week catch-up reviews — see the example below
+
+```yaml
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 14 * * WED"
+
+jobs:
+  facilitate-review:
+    uses: artsy/duchamp/.github/workflows/incident-facilitate-review.yml@main
+    with:
+      schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
+      meeting-weekday: ${{ vars.MEETING_WEEKDAY }}
+      meeting-hour: ${{ vars.MEETING_HOUR }}
+      meeting-minute: ${{ vars.MEETING_MINUTE }}
+      # A routine cron only needs to see 1 day ahead; a manual catch-up
+      # trigger needs enough slack to reach an off-week exceptions date.
+      lookahead-days: ${{ github.event_name == 'schedule' && 1 || 6 }}
+      dates: ${{ vars.DATES }}
+    secrets:
+      incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+See joule's `facilitate-incident-review.yml` for the fully-annotated production version.
+
+**Features:**
+
+- Queries incident.io's `/v2/schedule_entries` at the actual meeting instant — not the day the workflow runs — so an on-call override added after the day-before notification (but before the meeting) is still correctly reflected in who gets picked
+- Scans forward from the run day, up to `lookahead-days` days ahead, for the next date that's either a regular biweekly on-week occurrence of `meeting-weekday`, or an explicit date listed in `dates.exceptions` (any weekday) — this is what lets a single reusable workflow serve both the routine 1-day-ahead cron check and a rare manual catch-up trigger several days ahead of an off-cadence meeting
+- Incident Reviews run every other week: `dates` (`{ baseDate, exceptions }`) anchors that cadence — `baseDate` is a date known to fall on an on-week, and parity alternates every 7 days via exact day-level integer arithmetic (never drifts, no matter how old `baseDate` gets); a date listed in `exceptions` always forces an on-week, for a deliberate catch-up review during what would otherwise be an off-week
+- Picks one random participant from whoever is actually on-call at the resolved meeting instant (naturally covers however many rotations the schedule has, not hardcoded to a specific count)
+- Posts an explicit `:warning:` notice instead of a silent/empty mention if nobody on-call can be reached on Slack (no linked account)
+- Silently skips posting to Slack (logs to the run's console output instead) when no qualifying meeting date falls within the lookahead window
+
+**Inputs:**
+
+- `schedule-id` (required): incident.io schedule ID to query
+- `node-version` (optional): Node.js version to use
+- `meeting-weekday` (optional): Day of week the Incident Review meeting itself runs, `0` (Sunday) through `6` (Saturday). Default: `4` (Thursday)
+- `meeting-hour` (optional): Hour the meeting runs, `0`-`23`, in America/New_York time. Default: `11`
+- `meeting-minute` (optional): Minute the meeting runs, `0`-`59`. Default: `30` (11:30am ET)
+- `lookahead-days` (required): Days ahead of the run to search for a qualifying meeting date. A routine day-before cron only needs `1`; an occasional manual catch-up trigger needs enough slack to reach an off-week `exceptions` date on any weekday (e.g. `6`, to cover a Friday trigger for the following Monday)
+- `dates` (required): JSON `{ baseDate: string, exceptions: string[] }` — biweekly cadence anchor and any catch-up override dates, each a `YYYY-MM-DD` meeting date (not the day-before notification date)
+
+**Secrets:**
+
+- `incident-io-api-key` (required): incident.io API key with access to the schedule
+- `slack-webhook-url` (required): Slack incoming webhook URL to post the notice to
+
+---
+
 ## Reusable Action
 
 ### setup-and-install
@@ -513,6 +571,7 @@ The specific values above reflect one real cadence (a generous Friday-midnight c
 | Notion task tracking            | `link-pr-to-notion.yml`             | Links PRs to Notion tasks by short ID |
 | Scheduled on-call Slack reminders | `incident-standup-reminder.yml`   | Sources current on-call from incident.io |
 | Scheduled upcoming on-call reminders | `incident-next-on-call.yml`    | Notifies engineers ahead of their shift starting |
+| Scheduled Incident Review facilitator selection | `incident-facilitate-review.yml` | Picks a random on-call participant to facilitate |
 | Custom workflows                | `setup-and-install` action           | Use as a step in custom workflows    |
 
 ## Security Considerations

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -481,6 +481,11 @@ The specific values above reflect one real cadence (a generous Friday-midnight c
 ```yaml
 on:
   workflow_dispatch:
+    inputs:
+      meeting-date:
+        description: "Override meeting date (YYYY-MM-DD) — only for a rare off-week catch-up review, leave blank otherwise"
+        required: false
+        type: string
   schedule:
     - cron: "0 14 * * WED"
 
@@ -492,25 +497,24 @@ jobs:
       meeting-weekday: ${{ vars.MEETING_WEEKDAY }}
       meeting-hour: ${{ vars.MEETING_HOUR }}
       meeting-minute: ${{ vars.MEETING_MINUTE }}
-      # A routine cron only needs to see 1 day ahead; a manual catch-up
-      # trigger needs enough slack to reach an off-week exceptions date.
-      lookahead-days: ${{ github.event_name == 'schedule' && 1 || 6 }}
-      dates: ${{ vars.DATES }}
+      base-date: ${{ vars.MEETING_BASE_DATE }}
+      override-date: ${{ github.event.inputs.meeting-date }}
     secrets:
       incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 
-See joule's `facilitate-incident-review.yml` for the fully-annotated production version.
+See joule's `facilitate-incident-review.yml` for production version.
 
 **Features:**
 
 - Queries incident.io's `/v2/schedule_entries` at the actual meeting instant — not the day the workflow runs — so an on-call override added after the day-before notification (but before the meeting) is still correctly reflected in who gets picked
-- Scans forward from the run day, up to `lookahead-days` days ahead, for the next date that's either a regular biweekly on-week occurrence of `meeting-weekday`, or an explicit date listed in `dates.exceptions` (any weekday) — this is what lets a single reusable workflow serve both the routine 1-day-ahead cron check and a rare manual catch-up trigger several days ahead of an off-cadence meeting
-- Incident Reviews run every other week: `dates` (`{ baseDate, exceptions }`) anchors that cadence — `baseDate` is a date known to fall on an on-week, and parity alternates every 7 days via exact day-level integer arithmetic (never drifts, no matter how old `baseDate` gets); a date listed in `exceptions` always forces an on-week, for a deliberate catch-up review during what would otherwise be an off-week
+- Routine path (no `override-date`): checks tomorrow specifically, since the caller always runs the day before the meeting — skips unless tomorrow is both `meeting-weekday` and a biweekly on-week. It deliberately doesn't search further ahead; if this week is off, next week's cron run checks again on its own
+- Manual catch-up path (`override-date` set): targets that date directly, on any weekday, bypassing the on/off-week check entirely — meant to be filled in at `workflow_dispatch` trigger time for a rare off-week catch-up review
+- Incident Reviews run every other week: `base-date` anchors that cadence — a date known to fall on an on-week, with parity alternating every 7 days via exact day-level integer arithmetic (never drifts, no matter how old `base-date` gets)
 - Picks one random participant from whoever is actually on-call at the resolved meeting instant (naturally covers however many rotations the schedule has, not hardcoded to a specific count)
 - Posts an explicit `:warning:` notice instead of a silent/empty mention if nobody on-call can be reached on Slack (no linked account)
-- Silently skips posting to Slack (logs to the run's console output instead) when no qualifying meeting date falls within the lookahead window
+- Silently skips posting to Slack (logs to the run's console output instead) when the routine path finds no qualifying meeting date
 
 **Inputs:**
 
@@ -519,8 +523,8 @@ See joule's `facilitate-incident-review.yml` for the fully-annotated production 
 - `meeting-weekday` (optional): Day of week the Incident Review meeting itself runs, `0` (Sunday) through `6` (Saturday). Default: `4` (Thursday)
 - `meeting-hour` (optional): Hour the meeting runs, `0`-`23`, in America/New_York time. Default: `11`
 - `meeting-minute` (optional): Minute the meeting runs, `0`-`59`. Default: `30` (11:30am ET)
-- `lookahead-days` (required): Days ahead of the run to search for a qualifying meeting date. A routine day-before cron only needs `1`; an occasional manual catch-up trigger needs enough slack to reach an off-week `exceptions` date on any weekday (e.g. `6`, to cover a Friday trigger for the following Monday)
-- `dates` (required): JSON `{ baseDate: string, exceptions: string[] }` — biweekly cadence anchor and any catch-up override dates, each a `YYYY-MM-DD` meeting date (not the day-before notification date). `baseDate` must fall on the same weekday as `meeting-weekday` — a mismatch (e.g. the meeting day changes but `baseDate` isn't updated to a date on the new weekday) causes the run to fail loudly rather than silently compute the wrong on/off-week parity
+- `base-date` (required): `YYYY-MM-DD` date known to fall on a biweekly on-week — anchors the every-other-week cadence. Must fall on the same weekday as `meeting-weekday` — a mismatch (e.g. the meeting day changes but `base-date` isn't updated to a date on the new weekday) causes the run to fail loudly rather than silently compute the wrong on/off-week parity
+- `override-date` (optional): `YYYY-MM-DD` to target directly, bypassing the on/off-week check — for a rare manual catch-up review on an off-week or non-standard weekday. Leave unset for the routine day-before cron run
 
 **Secrets:**
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -494,17 +494,17 @@ jobs:
     uses: artsy/duchamp/.github/workflows/incident-facilitate-review.yml@main
     with:
       schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
-      meeting-weekday: ${{ vars.MEETING_WEEKDAY }}
-      meeting-hour: ${{ vars.MEETING_HOUR }}
-      meeting-minute: ${{ vars.MEETING_MINUTE }}
-      base-date: ${{ vars.MEETING_BASE_DATE }}
+      meeting-weekday: 4 # Thursday
+      meeting-hour: 11
+      meeting-minute: 30
+      base-date: "2023-04-27"
       override-date: ${{ github.event.inputs.meeting-date }}
     secrets:
       incident-io-api-key: ${{ secrets.INCIDENT_IO_API_KEY }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 
-See joule's `facilitate-incident-review.yml` for production version.
+joule's real workflow sources these values from repo vars instead of literals, so they can be changed without a duchamp PR — see joule's `facilitate-incident-review.yml` for that version.
 
 **Features:**
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -524,7 +524,7 @@ joule's real workflow sources these values from repo vars instead of literals, s
 - `meeting-hour` (optional): Hour the meeting runs, `0`-`23`, in America/New_York time. Default: `11`
 - `meeting-minute` (optional): Minute the meeting runs, `0`-`59`. Default: `30` (11:30am ET)
 - `base-date` (required): `YYYY-MM-DD` date known to fall on a biweekly on-week — anchors the every-other-week cadence. Must fall on the same weekday as `meeting-weekday` — a mismatch (e.g. the meeting day changes but `base-date` isn't updated to a date on the new weekday) causes the run to fail loudly rather than silently compute the wrong on/off-week parity
-- `override-date` (optional): `YYYY-MM-DD` to target directly, bypassing the on/off-week check — for a rare manual catch-up review on an off-week or non-standard weekday. Leave unset for the routine day-before cron run. Must resolve to a future instant — a past or current date is rejected, rather than silently posting a facilitator notice for a meeting that's already happened
+- `override-date` (optional): `YYYY-MM-DD` to target directly, bypassing the on/off-week check — for a rare manual catch-up review on an off-week or non-standard weekday. Leave unset (or blank/whitespace) for the routine day-before cron run. Must resolve to a future instant no more than 60 days out — a past, current, or far-future date (e.g. a year typo) is rejected, rather than silently posting a facilitator notice for the wrong meeting
 
 **Secrets:**
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -508,13 +508,13 @@ See joule's `facilitate-incident-review.yml` for production version.
 
 **Features:**
 
-- Queries incident.io's `/v2/schedule_entries` at the actual meeting instant — not the day the workflow runs — so an on-call override added after the day-before notification (but before the meeting) is still correctly reflected in who gets picked
-- Routine path (no `override-date`): checks tomorrow specifically, since the caller always runs the day before the meeting — skips unless tomorrow is both `meeting-weekday` and a biweekly on-week. It deliberately doesn't search further ahead; if this week is off, next week's cron run checks again on its own
+- Queries incident.io's `/v2/schedule_entries` at the actual meeting instant, not the day the workflow runs — so an override already on the schedule by run time is honored even if it doesn't take effect until later, between the run and the meeting. The query happens once, at run time; an override entered after that point isn't seen
+- Routine path (no `override-date`): checks tomorrow specifically, since the caller always runs the day before the meeting — computed in `meeting-hour`'s timezone (America/New_York) civil time, not raw UTC, since a cron's UTC firing instant can already be on a different UTC calendar date than its ET civil date. Throws if tomorrow isn't `meeting-weekday` at all (a real misconfiguration — the cron and `meeting-weekday` have drifted out of sync), but silently skips for the legitimate, expected case of an off-week. It deliberately doesn't search further ahead; if this week is off, next week's cron run checks again on its own
 - Manual catch-up path (`override-date` set): targets that date directly, on any weekday, bypassing the on/off-week check entirely — meant to be filled in at `workflow_dispatch` trigger time for a rare off-week catch-up review
 - Incident Reviews run every other week: `base-date` anchors that cadence — a date known to fall on an on-week, with parity alternating every 7 days via exact day-level integer arithmetic (never drifts, no matter how old `base-date` gets)
 - Picks one random participant from whoever is actually on-call at the resolved meeting instant (naturally covers however many rotations the schedule has, not hardcoded to a specific count)
 - Posts an explicit `:warning:` notice instead of a silent/empty mention if nobody on-call can be reached on Slack (no linked account)
-- Silently skips posting to Slack (logs to the run's console output instead) when the routine path finds no qualifying meeting date
+- Silently skips posting to Slack (logs to the run's console output instead) when the routine path lands on a legitimate off-week
 
 **Inputs:**
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -508,25 +508,24 @@ joule's real workflow sources these values from repo vars instead of literals, s
 
 **Features:**
 
-- Queries incident.io's `/v2/schedule_entries` at the actual meeting instant, not the day the workflow runs — so an override already on the schedule by run time is honored even if it doesn't take effect until later, between the run and the meeting. The query happens once, at run time; an override entered after that point isn't seen
-- Routine path (no `override-date`): checks tomorrow specifically, since the caller always runs the day before the meeting — computed in `meeting-hour`'s timezone (America/New_York) civil time, not raw UTC, since a cron's UTC firing instant can already be on a different UTC calendar date than its ET civil date. Throws if tomorrow isn't `meeting-weekday` at all (a real misconfiguration — the cron and `meeting-weekday` have drifted out of sync), but silently skips for the legitimate, expected case of an off-week. It deliberately doesn't search further ahead; if this week is off, next week's cron run checks again on its own
-- Manual catch-up path (`override-date` set): targets that date directly, on any weekday, bypassing the on/off-week check entirely — meant to be filled in at `workflow_dispatch` trigger time for a rare off-week catch-up review
-- Incident Reviews run every other week: `base-date` anchors that cadence — a date known to fall on an on-week, with parity alternating every 7 days via exact day-level integer arithmetic (never drifts, no matter how old `base-date` gets)
-- Picks one random participant from whoever is actually on-call at the resolved meeting instant (naturally covers however many rotations the schedule has, not hardcoded to a specific count)
-- Posts an explicit `:warning:` notice instead of a silent/empty mention when nobody on-call is reachable on Slack — whether that's a schedule gap or on-call participants with no linked Slack account
-- Silently skips posting to Slack (logs to the run's console output instead) when the routine path lands on a legitimate off-week
+- Queries incident.io at the actual meeting instant, not the day the workflow runs, so a schedule change made between run and meeting is still honored
+- Routine path (no `override-date`): runs the day before the meeting, computed in ET civil time (not raw UTC, since a cron's UTC firing instant can land on a different calendar date). Skips silently on an off-week; throws if tomorrow isn't `meeting-weekday` (cron/config drift)
+- Manual catch-up path (`override-date` set): targets that date directly on any weekday, bypassing the on/off-week check — meant for a rare off-week catch-up review
+- `base-date` anchors the every-other-week cadence via exact day-level arithmetic, so it never drifts no matter how old it gets
+- Picks one random participant from whoever is actually on-call at the resolved meeting instant
+- Posts an explicit `:warning:` notice instead of a silent/empty mention when nobody on-call is reachable on Slack
 
 **Inputs:**
 
 - `schedule-id` (required): incident.io schedule ID to query
 - `node-version` (optional): Node.js version to use
-- `meeting-weekday` (optional, `type: string`): Day of week the Incident Review meeting itself runs, `0` (Sunday) through `6` (Saturday). Default: `4` (Thursday)
+- `meeting-weekday` (optional, `type: string`): Day of week the meeting runs, `0` (Sunday) through `6` (Saturday). Default: `4` (Thursday)
 - `meeting-hour` (optional, `type: string`): Hour the meeting runs, `0`-`23`, in America/New_York time. Default: `11`
-- `meeting-minute` (optional, `type: string`): Minute the meeting runs, `0`-`59`. Default: `30` (11:30am ET)
-- `base-date` (required): `YYYY-MM-DD` date known to fall on a biweekly on-week — anchors the every-other-week cadence. Must fall on the same weekday as `meeting-weekday` — a mismatch (e.g. the meeting day changes but `base-date` isn't updated to a date on the new weekday) causes the run to fail loudly rather than silently compute the wrong on/off-week parity
-- `override-date` (optional): `YYYY-MM-DD` to target directly, bypassing the on/off-week check — for a rare manual catch-up review on an off-week or non-standard weekday. Leave unset (or blank/whitespace) for the routine day-before cron run. Must resolve to a future instant no more than 60 days out — a past, current, or far-future date (e.g. a year typo) is rejected, rather than silently posting a facilitator notice for the wrong meeting
+- `meeting-minute` (optional, `type: string`): Minute the meeting runs, `0`-`59`. Default: `30`
+- `base-date` (required): `YYYY-MM-DD` date known to fall on an on-week, on the same weekday as `meeting-weekday`
+- `override-date` (optional): `YYYY-MM-DD` to target directly for a manual catch-up review, bypassing the on/off-week check. Must resolve to a future date no more than 60 days out (catches a year typo)
 
-`meeting-weekday`/`meeting-hour`/`meeting-minute` are deliberately `type: string`, not `type: number`: a caller passing an unset `vars.*` through one of them (e.g. `${{ vars.MEETING_HOUR }}`) needs the empty case to stay an empty string. A `type: number` input coerces that same empty value to a literal `0` instead of the default declared here — a real GitHub Actions behavior ([actions/runner#2907](https://github.com/actions/runner/issues/2907)), not a hypothetical.
+`meeting-weekday`/`meeting-hour`/`meeting-minute` are `type: string`, not `type: number`, because GitHub Actions coerces an unset `type: number` input to `0` rather than falling back to the declared default ([actions/runner#2907](https://github.com/actions/runner/issues/2907)).
 
 **Secrets:**
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -524,7 +524,7 @@ joule's real workflow sources these values from repo vars instead of literals, s
 - `meeting-hour` (optional): Hour the meeting runs, `0`-`23`, in America/New_York time. Default: `11`
 - `meeting-minute` (optional): Minute the meeting runs, `0`-`59`. Default: `30` (11:30am ET)
 - `base-date` (required): `YYYY-MM-DD` date known to fall on a biweekly on-week — anchors the every-other-week cadence. Must fall on the same weekday as `meeting-weekday` — a mismatch (e.g. the meeting day changes but `base-date` isn't updated to a date on the new weekday) causes the run to fail loudly rather than silently compute the wrong on/off-week parity
-- `override-date` (optional): `YYYY-MM-DD` to target directly, bypassing the on/off-week check — for a rare manual catch-up review on an off-week or non-standard weekday. Leave unset for the routine day-before cron run
+- `override-date` (optional): `YYYY-MM-DD` to target directly, bypassing the on/off-week check — for a rare manual catch-up review on an off-week or non-standard weekday. Leave unset for the routine day-before cron run. Must resolve to a future instant — a past or current date is rejected, rather than silently posting a facilitator notice for a meeting that's already happened
 
 **Secrets:**
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -494,9 +494,9 @@ jobs:
     uses: artsy/duchamp/.github/workflows/incident-facilitate-review.yml@main
     with:
       schedule-id: ${{ vars.INCIDENT_IO_SCHEDULE_ID }}
-      meeting-weekday: 4 # Thursday
-      meeting-hour: 11
-      meeting-minute: 30
+      meeting-weekday: "4" # Thursday
+      meeting-hour: "11"
+      meeting-minute: "30"
       base-date: "2023-04-27"
       override-date: ${{ github.event.inputs.meeting-date }}
     secrets:
@@ -520,11 +520,13 @@ joule's real workflow sources these values from repo vars instead of literals, s
 
 - `schedule-id` (required): incident.io schedule ID to query
 - `node-version` (optional): Node.js version to use
-- `meeting-weekday` (optional): Day of week the Incident Review meeting itself runs, `0` (Sunday) through `6` (Saturday). Default: `4` (Thursday)
-- `meeting-hour` (optional): Hour the meeting runs, `0`-`23`, in America/New_York time. Default: `11`
-- `meeting-minute` (optional): Minute the meeting runs, `0`-`59`. Default: `30` (11:30am ET)
+- `meeting-weekday` (optional, `type: string`): Day of week the Incident Review meeting itself runs, `0` (Sunday) through `6` (Saturday). Default: `4` (Thursday)
+- `meeting-hour` (optional, `type: string`): Hour the meeting runs, `0`-`23`, in America/New_York time. Default: `11`
+- `meeting-minute` (optional, `type: string`): Minute the meeting runs, `0`-`59`. Default: `30` (11:30am ET)
 - `base-date` (required): `YYYY-MM-DD` date known to fall on a biweekly on-week — anchors the every-other-week cadence. Must fall on the same weekday as `meeting-weekday` — a mismatch (e.g. the meeting day changes but `base-date` isn't updated to a date on the new weekday) causes the run to fail loudly rather than silently compute the wrong on/off-week parity
 - `override-date` (optional): `YYYY-MM-DD` to target directly, bypassing the on/off-week check — for a rare manual catch-up review on an off-week or non-standard weekday. Leave unset (or blank/whitespace) for the routine day-before cron run. Must resolve to a future instant no more than 60 days out — a past, current, or far-future date (e.g. a year typo) is rejected, rather than silently posting a facilitator notice for the wrong meeting
+
+`meeting-weekday`/`meeting-hour`/`meeting-minute` are deliberately `type: string`, not `type: number`: a caller passing an unset `vars.*` through one of them (e.g. `${{ vars.MEETING_HOUR }}`) needs the empty case to stay an empty string. A `type: number` input coerces that same empty value to a literal `0` instead of the default declared here — a real GitHub Actions behavior ([actions/runner#2907](https://github.com/actions/runner/issues/2907)), not a hypothetical.
 
 **Secrets:**
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -520,7 +520,7 @@ See joule's `facilitate-incident-review.yml` for the fully-annotated production 
 - `meeting-hour` (optional): Hour the meeting runs, `0`-`23`, in America/New_York time. Default: `11`
 - `meeting-minute` (optional): Minute the meeting runs, `0`-`59`. Default: `30` (11:30am ET)
 - `lookahead-days` (required): Days ahead of the run to search for a qualifying meeting date. A routine day-before cron only needs `1`; an occasional manual catch-up trigger needs enough slack to reach an off-week `exceptions` date on any weekday (e.g. `6`, to cover a Friday trigger for the following Monday)
-- `dates` (required): JSON `{ baseDate: string, exceptions: string[] }` — biweekly cadence anchor and any catch-up override dates, each a `YYYY-MM-DD` meeting date (not the day-before notification date)
+- `dates` (required): JSON `{ baseDate: string, exceptions: string[] }` — biweekly cadence anchor and any catch-up override dates, each a `YYYY-MM-DD` meeting date (not the day-before notification date). `baseDate` must fall on the same weekday as `meeting-weekday` — a mismatch (e.g. the meeting day changes but `baseDate` isn't updated to a date on the new weekday) causes the run to fail loudly rather than silently compute the wrong on/off-week parity
 
 **Secrets:**
 

--- a/scripts/on-call/biweekly.test.ts
+++ b/scripts/on-call/biweekly.test.ts
@@ -1,53 +1,28 @@
-import { type BiweeklySchedule, isOffWeek } from "./biweekly"
+import { isOffWeek } from "./biweekly"
 
-// baseDate is a real joule repo var (`DATES`); 2026-07-16 was confirmed by
-// the user as a real Incident Review day, notified the prior day (2026-07-15).
-const SCHEDULE: BiweeklySchedule = {
-  baseDate: "2023-04-27",
-  exceptions: [],
-}
+// A real joule repo var; 2026-07-16 was confirmed by the user as a real
+// Incident Review day, notified the prior day (2026-07-15).
+const BASE_DATE = "2023-04-27"
 
 describe("isOffWeek", () => {
   it("treats baseDate itself as an on-week (it's defined as a review day)", () => {
-    expect(isOffWeek(SCHEDULE, new Date("2023-04-27T18:00:00Z"))).toBe(false)
+    expect(isOffWeek(BASE_DATE, new Date("2023-04-27T18:00:00Z"))).toBe(false)
   })
 
   it("treats the confirmed real review day as an on-week", () => {
-    expect(isOffWeek(SCHEDULE, new Date("2026-07-16T18:00:00Z"))).toBe(false)
+    expect(isOffWeek(BASE_DATE, new Date("2026-07-16T18:00:00Z"))).toBe(false)
   })
 
   it("treats the following Thursday (no review) as an off-week", () => {
-    expect(isOffWeek(SCHEDULE, new Date("2026-07-23T18:00:00Z"))).toBe(true)
+    expect(isOffWeek(BASE_DATE, new Date("2026-07-23T18:00:00Z"))).toBe(true)
   })
 
   it("treats the Thursday after that as an on-week again", () => {
-    expect(isOffWeek(SCHEDULE, new Date("2026-07-30T18:00:00Z"))).toBe(false)
+    expect(isOffWeek(BASE_DATE, new Date("2026-07-30T18:00:00Z"))).toBe(false)
   })
 
   it("ignores time-of-day, only the UTC calendar date matters", () => {
-    expect(isOffWeek(SCHEDULE, new Date("2026-07-23T00:00:01Z"))).toBe(true)
-    expect(isOffWeek(SCHEDULE, new Date("2026-07-23T23:59:59Z"))).toBe(true)
-  })
-
-  it("force-flips an off-week to on-week when the date is listed in exceptions", () => {
-    const withCatchUp: BiweeklySchedule = {
-      ...SCHEDULE,
-      exceptions: ["2026-07-23"],
-    }
-
-    expect(isOffWeek(withCatchUp, new Date("2026-07-23T18:00:00Z"))).toBe(
-      false
-    )
-  })
-
-  it("does not affect a date not listed in exceptions", () => {
-    const withCatchUp: BiweeklySchedule = {
-      ...SCHEDULE,
-      exceptions: ["2026-08-06"],
-    }
-
-    expect(isOffWeek(withCatchUp, new Date("2026-07-23T18:00:00Z"))).toBe(
-      true
-    )
+    expect(isOffWeek(BASE_DATE, new Date("2026-07-23T00:00:01Z"))).toBe(true)
+    expect(isOffWeek(BASE_DATE, new Date("2026-07-23T23:59:59Z"))).toBe(true)
   })
 })

--- a/scripts/on-call/biweekly.test.ts
+++ b/scripts/on-call/biweekly.test.ts
@@ -1,0 +1,53 @@
+import { type BiweeklySchedule, isOffWeek } from "./biweekly"
+
+// baseDate is a real joule repo var (`DATES`); 2026-07-16 was confirmed by
+// the user as a real Incident Review day, notified the prior day (2026-07-15).
+const SCHEDULE: BiweeklySchedule = {
+  baseDate: "2023-04-27",
+  exceptions: [],
+}
+
+describe("isOffWeek", () => {
+  it("treats baseDate itself as an on-week (it's defined as a review day)", () => {
+    expect(isOffWeek(SCHEDULE, new Date("2023-04-27T18:00:00Z"))).toBe(false)
+  })
+
+  it("treats the confirmed real review day as an on-week", () => {
+    expect(isOffWeek(SCHEDULE, new Date("2026-07-16T18:00:00Z"))).toBe(false)
+  })
+
+  it("treats the following Thursday (no review) as an off-week", () => {
+    expect(isOffWeek(SCHEDULE, new Date("2026-07-23T18:00:00Z"))).toBe(true)
+  })
+
+  it("treats the Thursday after that as an on-week again", () => {
+    expect(isOffWeek(SCHEDULE, new Date("2026-07-30T18:00:00Z"))).toBe(false)
+  })
+
+  it("ignores time-of-day, only the UTC calendar date matters", () => {
+    expect(isOffWeek(SCHEDULE, new Date("2026-07-23T00:00:01Z"))).toBe(true)
+    expect(isOffWeek(SCHEDULE, new Date("2026-07-23T23:59:59Z"))).toBe(true)
+  })
+
+  it("force-flips an off-week to on-week when the date is listed in exceptions", () => {
+    const withCatchUp: BiweeklySchedule = {
+      ...SCHEDULE,
+      exceptions: ["2026-07-23"],
+    }
+
+    expect(isOffWeek(withCatchUp, new Date("2026-07-23T18:00:00Z"))).toBe(
+      false
+    )
+  })
+
+  it("does not affect a date not listed in exceptions", () => {
+    const withCatchUp: BiweeklySchedule = {
+      ...SCHEDULE,
+      exceptions: ["2026-08-06"],
+    }
+
+    expect(isOffWeek(withCatchUp, new Date("2026-07-23T18:00:00Z"))).toBe(
+      true
+    )
+  })
+})

--- a/scripts/on-call/biweekly.test.ts
+++ b/scripts/on-call/biweekly.test.ts
@@ -1,7 +1,8 @@
 import { isOffWeek } from "./biweekly"
 
-// A real joule repo var; 2026-07-16 was confirmed by the user as a real
-// Incident Review day, notified the prior day (2026-07-15).
+// A real joule repo var (2023-04-27); 2026-07-16 is a real Incident Review
+// day (168 weeks out from base date — even, so on-week), notified the prior
+// day (2026-07-15).
 const BASE_DATE = "2023-04-27"
 
 describe("isOffWeek", () => {

--- a/scripts/on-call/biweekly.ts
+++ b/scripts/on-call/biweekly.ts
@@ -1,22 +1,16 @@
-// Incident Reviews run every other week. `baseDate` anchors a date known to
-// fall on an on-week; parity alternates every 7 days from there via exact
-// day-level integer arithmetic, so it never drifts no matter how old
-// `baseDate` gets (unlike wall-clock/float-based approaches).
+// Incident Reviews run every other week. `baseDate` anchors a known on-week;
+// parity alternates every 7 days via exact day-level integer arithmetic, so
+// it never drifts no matter how old `baseDate` gets.
 
 import { MS_PER_DAY } from "./shift-boundary"
 
 const toUtcDateOnly = (date: Date): number =>
   Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
 
-// Whether `at` (its UTC calendar date) falls on an off-week.
-//
-// Assumes `at` falls on the same weekday as `baseDate` (both are meeting
-// days) — callers only invoke this for dates that already matched the
-// configured meeting weekday, so `target` and `base` are always an exact
-// multiple of 7 days apart. `baseDate` is itself defined as an on-week
-// occurrence, so `weeksSince === 0` (and any even multiple of it) must
-// resolve to on-week — matches joule's real `MEETING_BASE_DATE` (2023-04-27)
-// and its real Incident Review on 2026-07-16 (168 weeks out, even).
+// Whether `at` falls on an off-week. Assumes `at` and `baseDate` share the
+// same weekday — callers only pass dates that already matched the meeting
+// weekday, so they're always a whole number of weeks apart — and that
+// `baseDate` itself is an on-week, so an even weeksSince means on-week.
 export const isOffWeek = (baseDate: string, at: Date): boolean => {
   const base = toUtcDateOnly(new Date(`${baseDate}T00:00:00Z`))
   const target = toUtcDateOnly(at)

--- a/scripts/on-call/biweekly.ts
+++ b/scripts/on-call/biweekly.ts
@@ -3,7 +3,7 @@
 // day-level integer arithmetic, so it never drifts no matter how old
 // `baseDate` gets (unlike wall-clock/float-based approaches).
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000
+import { MS_PER_DAY } from "./shift-boundary"
 
 const toUtcDateOnly = (date: Date): number =>
   Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())

--- a/scripts/on-call/biweekly.ts
+++ b/scripts/on-call/biweekly.ts
@@ -3,37 +3,22 @@
 // day-level integer arithmetic, so it never drifts no matter how old
 // `baseDate` gets (unlike wall-clock/float-based approaches).
 
-export interface BiweeklySchedule {
-  baseDate: string // UTC YYYY-MM-DD, a date when a review SHOULD happen
-  exceptions: string[] // UTC YYYY-MM-DD dates that force an on-week regardless of parity
-}
-
 const MS_PER_DAY = 24 * 60 * 60 * 1000
 
 const toUtcDateOnly = (date: Date): number =>
   Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
 
-const toUtcDateString = (date: Date): string => date.toISOString().slice(0, 10)
-
-// Whether `at` (its UTC calendar date) falls on an off-week. A date listed in
-// `exceptions` always forces an on-week — e.g. a deliberate catch-up review
-// scheduled during what would otherwise be an off-week to clear backlogged
-// postmortems.
+// Whether `at` (its UTC calendar date) falls on an off-week.
 //
 // Assumes `at` falls on the same weekday as `baseDate` (both are meeting
-// days, not the day-before notification day) — callers only invoke this for
-// dates that already matched the configured meeting weekday, so `target` and
-// `base` are always an exact multiple of 7 days apart. `baseDate` is itself
-// defined as an on-week occurrence, so `weeksSince === 0` (and any even
-// multiple of it) must resolve to on-week — verified against a real
-// confirmed review day (2026-07-16, `weeksSince` 168, even).
-export const isOffWeek = (schedule: BiweeklySchedule, at: Date): boolean => {
-  const atDateString = toUtcDateString(at)
-  if (schedule.exceptions.includes(atDateString)) {
-    return false
-  }
-
-  const base = toUtcDateOnly(new Date(`${schedule.baseDate}T00:00:00Z`))
+// days) — callers only invoke this for dates that already matched the
+// configured meeting weekday, so `target` and `base` are always an exact
+// multiple of 7 days apart. `baseDate` is itself defined as an on-week
+// occurrence, so `weeksSince === 0` (and any even multiple of it) must
+// resolve to on-week — verified against a real confirmed review day
+// (2026-07-16, `weeksSince` 168, even).
+export const isOffWeek = (baseDate: string, at: Date): boolean => {
+  const base = toUtcDateOnly(new Date(`${baseDate}T00:00:00Z`))
   const target = toUtcDateOnly(at)
   const weeksSince = Math.floor((target - base) / MS_PER_DAY / 7)
 

--- a/scripts/on-call/biweekly.ts
+++ b/scripts/on-call/biweekly.ts
@@ -15,8 +15,8 @@ const toUtcDateOnly = (date: Date): number =>
 // configured meeting weekday, so `target` and `base` are always an exact
 // multiple of 7 days apart. `baseDate` is itself defined as an on-week
 // occurrence, so `weeksSince === 0` (and any even multiple of it) must
-// resolve to on-week — verified against a real confirmed review day
-// (2026-07-16, `weeksSince` 168, even).
+// resolve to on-week — matches joule's real `MEETING_BASE_DATE` (2023-04-27)
+// and its real Incident Review on 2026-07-16 (168 weeks out, even).
 export const isOffWeek = (baseDate: string, at: Date): boolean => {
   const base = toUtcDateOnly(new Date(`${baseDate}T00:00:00Z`))
   const target = toUtcDateOnly(at)

--- a/scripts/on-call/biweekly.ts
+++ b/scripts/on-call/biweekly.ts
@@ -1,0 +1,41 @@
+// Incident Reviews run every other week. `baseDate` anchors a date known to
+// fall on an on-week; parity alternates every 7 days from there via exact
+// day-level integer arithmetic, so it never drifts no matter how old
+// `baseDate` gets (unlike wall-clock/float-based approaches).
+
+export interface BiweeklySchedule {
+  baseDate: string // UTC YYYY-MM-DD, a date when a review SHOULD happen
+  exceptions: string[] // UTC YYYY-MM-DD dates that force an on-week regardless of parity
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+const toUtcDateOnly = (date: Date): number =>
+  Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+
+const toUtcDateString = (date: Date): string => date.toISOString().slice(0, 10)
+
+// Whether `at` (its UTC calendar date) falls on an off-week. A date listed in
+// `exceptions` always forces an on-week — e.g. a deliberate catch-up review
+// scheduled during what would otherwise be an off-week to clear backlogged
+// postmortems.
+//
+// Assumes `at` falls on the same weekday as `baseDate` (both are meeting
+// days, not the day-before notification day) — callers only invoke this for
+// dates that already matched the configured meeting weekday, so `target` and
+// `base` are always an exact multiple of 7 days apart. `baseDate` is itself
+// defined as an on-week occurrence, so `weeksSince === 0` (and any even
+// multiple of it) must resolve to on-week — verified against a real
+// confirmed review day (2026-07-16, `weeksSince` 168, even).
+export const isOffWeek = (schedule: BiweeklySchedule, at: Date): boolean => {
+  const atDateString = toUtcDateString(at)
+  if (schedule.exceptions.includes(atDateString)) {
+    return false
+  }
+
+  const base = toUtcDateOnly(new Date(`${schedule.baseDate}T00:00:00Z`))
+  const target = toUtcDateOnly(at)
+  const weeksSince = Math.floor((target - base) / MS_PER_DAY / 7)
+
+  return weeksSince % 2 !== 0
+}

--- a/scripts/on-call/env.test.ts
+++ b/scripts/on-call/env.test.ts
@@ -1,0 +1,75 @@
+import { readIntEnv, requireEnv, requireIntEnv } from "./env"
+
+describe("requireEnv", () => {
+  const originalEnv = process.env
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it("returns the value when set", () => {
+    process.env = { ...originalEnv, FOO: "bar" }
+    expect(requireEnv("FOO")).toBe("bar")
+  })
+
+  it("throws when unset", () => {
+    process.env = { ...originalEnv, FOO: undefined }
+    expect(() => requireEnv("FOO")).toThrow("FOO env var is not set.")
+  })
+})
+
+describe("readIntEnv", () => {
+  const originalEnv = process.env
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it("parses the env var when set", () => {
+    process.env = { ...originalEnv, FOO: "5" }
+    expect(readIntEnv("FOO", 1, { min: 0, max: 10 })).toBe(5)
+  })
+
+  it("falls back to the default when unset", () => {
+    process.env = { ...originalEnv, FOO: undefined }
+    expect(readIntEnv("FOO", 7, { min: 0, max: 10 })).toBe(7)
+  })
+
+  it("throws when out of range", () => {
+    process.env = { ...originalEnv, FOO: "11" }
+    expect(() => readIntEnv("FOO", 1, { min: 0, max: 10 })).toThrow(
+      'Invalid FOO: "11". Must be an integer between 0 and 10.'
+    )
+  })
+
+  it("throws when not an integer", () => {
+    process.env = { ...originalEnv, FOO: "abc" }
+    expect(() => readIntEnv("FOO", 1, { min: 0, max: 10 })).toThrow(
+      'Invalid FOO: "abc". Must be an integer between 0 and 10.'
+    )
+  })
+})
+
+describe("requireIntEnv", () => {
+  const originalEnv = process.env
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it("parses the env var when set", () => {
+    process.env = { ...originalEnv, FOO: "5" }
+    expect(requireIntEnv("FOO", { min: 0, max: 10 })).toBe(5)
+  })
+
+  it("throws when unset", () => {
+    process.env = { ...originalEnv, FOO: undefined }
+    expect(() => requireIntEnv("FOO", { min: 0, max: 10 })).toThrow(
+      "FOO env var is not set."
+    )
+  })
+
+  it("throws when out of range", () => {
+    process.env = { ...originalEnv, FOO: "11" }
+    expect(() => requireIntEnv("FOO", { min: 0, max: 10 })).toThrow(
+      'Invalid FOO: "11". Must be an integer between 0 and 10.'
+    )
+  })
+})

--- a/scripts/on-call/env.ts
+++ b/scripts/on-call/env.ts
@@ -1,0 +1,40 @@
+export const requireEnv = (name: string): string => {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} env var is not set.`)
+  }
+  return value
+}
+
+export const readIntEnv = (
+  name: string,
+  defaultValue: number,
+  range: { min: number; max: number }
+): number => {
+  const raw = process.env[name]
+  const value = raw ? Number.parseInt(raw, 10) : defaultValue
+
+  if (Number.isNaN(value) || value < range.min || value > range.max) {
+    throw new Error(
+      `Invalid ${name}: "${raw}". Must be an integer between ${range.min} and ${range.max}.`
+    )
+  }
+
+  return value
+}
+
+export const requireIntEnv = (
+  name: string,
+  range: { min: number; max: number }
+): number => {
+  const raw = requireEnv(name)
+  const value = Number.parseInt(raw, 10)
+
+  if (Number.isNaN(value) || value < range.min || value > range.max) {
+    throw new Error(
+      `Invalid ${name}: "${raw}". Must be an integer between ${range.min} and ${range.max}.`
+    )
+  }
+
+  return value
+}

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -132,6 +132,17 @@ describe("resolveMeetingInstant", () => {
     )
   })
 
+  it("throws on an override date that doesn't exist on the calendar", () => {
+    // Date.UTC would silently roll this over to 2026-03-03.
+    const now = new Date("2026-02-01T14:00:00Z")
+
+    expect(() =>
+      resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, "2026-02-31")
+    ).toThrow(
+      'Invalid MEETING_OVERRIDE_DATE: "2026-02-31" is not a real calendar date.'
+    )
+  })
+
   it("resolves the meeting hour/minute DST-aware", () => {
     // baseDate === tomorrow itself, so weeksSince = 0 (on-week), isolating
     // this test from the real production parity data.

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -123,6 +123,25 @@ describe("resolveMeetingInstant", () => {
     expect(instant?.toISOString()).toBe("2026-07-27T15:30:00.000Z")
   })
 
+  it("throws when the override date is in the past", () => {
+    const now = new Date("2026-07-24T14:00:00Z")
+
+    expect(() =>
+      resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, "2026-07-20")
+    ).toThrow(
+      'MEETING_OVERRIDE_DATE "2026-07-20" resolves to 2026-07-20T15:30:00.000Z, which is not after now (2026-07-24T14:00:00.000Z). The override must target a future meeting.'
+    )
+  })
+
+  it("throws when the override date resolves to exactly now", () => {
+    // 2026-07-23 at 11:30am ET (EDT) is exactly 2026-07-23T15:30:00Z.
+    const now = new Date("2026-07-23T15:30:00.000Z")
+
+    expect(() =>
+      resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, "2026-07-23")
+    ).toThrow('is not after now')
+  })
+
   it("throws on a malformed override date", () => {
     const now = new Date("2026-07-24T14:00:00Z")
 

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -65,13 +65,29 @@ describe("resolveMeetingInstant", () => {
     expect(instant).toBeNull()
   })
 
-  it("returns null when tomorrow isn't meetingWeekday at all", () => {
-    // Any day where tomorrow isn't Thursday.
+  it("throws when tomorrow isn't meetingWeekday at all", () => {
+    // Any day where tomorrow isn't Thursday -- a real misconfiguration
+    // (cron/meetingWeekday mismatch), not the legitimate off-week case.
     const now = new Date("2026-07-16T14:00:00Z") // tomorrow is Friday
+
+    expect(() =>
+      resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, undefined)
+    ).toThrow(
+      "resolveMeetingInstant expected tomorrow (in America/New_York) to be weekday 4, but it's 5."
+    )
+  })
+
+  it("computes tomorrow in ET civil time, not raw UTC, for a cron that fires just after UTC midnight", () => {
+    // A cron meant for "Wednesday evening ET" has to fire at 2am UTC
+    // Thursday -- its UTC calendar date is already Thursday, but in ET civil
+    // time (EDT, UTC-4) it's still 10pm Wednesday. Naive UTC+1-day arithmetic
+    // would land on UTC-Friday and never match meetingWeekday=4 (Thursday);
+    // civil-day arithmetic correctly resolves tomorrow as ET-Thursday.
+    const now = new Date("2026-07-16T02:00:00Z")
 
     const instant = resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, undefined)
 
-    expect(instant).toBeNull()
+    expect(instant?.toISOString()).toBe("2026-07-16T15:30:00.000Z")
   })
 
   it("targets the override date directly, bypassing the on/off-week check", () => {

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -262,16 +262,20 @@ describe("main", () => {
     expect(contents).toContain(":warning:")
   })
 
-  it("logs the payload to stdout when GITHUB_OUTPUT is unset", async () => {
+  it("logs the candidate pool before picking, and the payload to stdout when GITHUB_OUTPUT is unset", async () => {
     jest.setSystemTime(new Date("2026-07-15T14:00:00Z"))
     process.env.INCIDENT_IO_API_KEY = "test-key"
     process.env.SCHEDULE_ID = "schedule-123"
+    mockUsersToMentions.mockReturnValue(["<@U_ALICE>", "<@U_BOB>"])
     const consoleSpy = jest.spyOn(console, "log").mockImplementation()
 
     await main()
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
-    expect(consoleSpy.mock.calls[0][0]).toContain("<@U_ALICE>")
+    expect(consoleSpy).toHaveBeenCalledTimes(2)
+    expect(consoleSpy.mock.calls[0][0]).toBe(
+      "facilitate-incident-review: choosing a facilitator from 2 on-call participant(s): <@U_ALICE>, <@U_BOB>"
+    )
+    expect(consoleSpy.mock.calls[1][0]).toMatch(/<@U_ALICE>|<@U_BOB>/)
     consoleSpy.mockRestore()
   })
 })

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -1,9 +1,8 @@
 import * as fs from "fs"
-import { type BiweeklySchedule } from "./biweekly"
 import {
   buildPayload,
-  findMeetingInstant,
   main,
+  resolveMeetingInstant,
 } from "./facilitate-incident-review"
 import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
 
@@ -18,12 +17,9 @@ const mockScheduleUrl = scheduleUrl as jest.Mock
 const SCHEDULE_URL =
   "https://app.incident.io/artsy/on-call/schedules/schedule-123"
 
-// Real joule DATES repo var; 2026-07-16 confirmed by the user as a real
+// A real joule repo var; 2026-07-16 confirmed by the user as a real
 // Incident Review day, 2026-07-23/2026-07-22 confirmed off-week.
-const REAL_SCHEDULE: BiweeklySchedule = {
-  baseDate: "2023-04-27",
-  exceptions: [],
-}
+const BASE_DATE = "2023-04-27"
 
 describe("buildPayload", () => {
   it("mentions the chosen facilitator and links the schedule + review doc", () => {
@@ -48,63 +44,92 @@ describe("buildPayload", () => {
   })
 })
 
-describe("findMeetingInstant", () => {
-  it("finds tomorrow's on-week Thursday meeting with a 1-day cron lookahead", () => {
-    // Wednesday 2026-07-15, an on-week per the real baseDate; the cron only
-    // ever needs to see 1 day ahead.
+describe("resolveMeetingInstant", () => {
+  it("targets tomorrow when it's an on-week occurrence of meetingWeekday", () => {
+    // Wednesday 2026-07-15, an on-week per the real base date; tomorrow
+    // (Thursday 2026-07-16) is the routine cron's target.
     const now = new Date("2026-07-15T14:00:00Z")
 
-    const instant = findMeetingInstant(now, 4, 11, 30, REAL_SCHEDULE, 1)
+    const instant = resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, undefined)
 
     // 2026-07-16 is EDT (UTC-4): 11:30am ET -> 3:30pm UTC.
     expect(instant?.toISOString()).toBe("2026-07-16T15:30:00.000Z")
   })
 
-  it("returns null on an off-week with a 1-day cron lookahead and no exception", () => {
+  it("returns null when tomorrow is an off-week", () => {
     // Wednesday 2026-07-22, an off-week; tomorrow (2026-07-23) has no review.
     const now = new Date("2026-07-22T14:00:00Z")
 
-    const instant = findMeetingInstant(now, 4, 11, 30, REAL_SCHEDULE, 1)
+    const instant = resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, undefined)
 
     expect(instant).toBeNull()
   })
 
-  it("finds a Monday catch-up exception with a wider manual-trigger lookahead", () => {
-    // Friday 2026-07-24, an off-week catch-up scheduled for Monday
-    // 2026-07-27 (a weekday that doesn't match the regular Thursday cadence
-    // at all) -- triggered 3 days ahead, within a 6-day manual lookahead.
+  it("returns null when tomorrow isn't meetingWeekday at all", () => {
+    // Any day where tomorrow isn't Thursday.
+    const now = new Date("2026-07-16T14:00:00Z") // tomorrow is Friday
+
+    const instant = resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, undefined)
+
+    expect(instant).toBeNull()
+  })
+
+  it("targets the override date directly, bypassing the on/off-week check", () => {
+    // 2026-07-23 is an off-week Thursday; an override should still target it.
+    const now = new Date("2026-07-20T14:00:00Z")
+
+    const instant = resolveMeetingInstant(
+      now,
+      4,
+      11,
+      30,
+      BASE_DATE,
+      "2026-07-23"
+    )
+
+    expect(instant?.toISOString()).toBe("2026-07-23T15:30:00.000Z")
+  })
+
+  it("targets an override date on any weekday, not just meetingWeekday", () => {
+    // Monday catch-up, doesn't match meetingWeekday (Thursday) at all.
     const now = new Date("2026-07-24T14:00:00Z")
-    const schedule: BiweeklySchedule = {
-      ...REAL_SCHEDULE,
-      exceptions: ["2026-07-27"],
-    }
 
-    const instant = findMeetingInstant(now, 4, 11, 30, schedule, 6)
+    const instant = resolveMeetingInstant(
+      now,
+      4,
+      11,
+      30,
+      BASE_DATE,
+      "2026-07-27"
+    )
 
-    // 2026-07-27 is still EDT: 11:30am ET -> 3:30pm UTC.
     expect(instant?.toISOString()).toBe("2026-07-27T15:30:00.000Z")
   })
 
-  it("returns null when nothing qualifies within the lookahead window", () => {
-    // Same off-week Friday, but no exception configured and the lookahead
-    // stays short of reaching any on-week Thursday.
+  it("throws on a malformed override date", () => {
     const now = new Date("2026-07-24T14:00:00Z")
 
-    const instant = findMeetingInstant(now, 4, 11, 30, REAL_SCHEDULE, 3)
-
-    expect(instant).toBeNull()
+    expect(() =>
+      resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, "07/27/2026")
+    ).toThrow(
+      'Invalid MEETING_OVERRIDE_DATE: "07/27/2026". Must be YYYY-MM-DD.'
+    )
   })
 
-  it("resolves the meeting hour/minute DST-aware for the candidate's own date", () => {
-    // baseDate === the candidate itself, so weeksSince = 0 (on-week),
-    // isolating this test from the real production parity data.
-    const winterSchedule: BiweeklySchedule = {
-      baseDate: "2027-01-07", // Thursday, EST (UTC-5)
-      exceptions: [],
-    }
+  it("resolves the meeting hour/minute DST-aware", () => {
+    // baseDate === tomorrow itself, so weeksSince = 0 (on-week), isolating
+    // this test from the real production parity data.
     const now = new Date("2027-01-06T14:00:00Z") // Wednesday before
+    const winterBaseDate = "2027-01-07" // Thursday, EST (UTC-5)
 
-    const instant = findMeetingInstant(now, 4, 11, 30, winterSchedule, 1)
+    const instant = resolveMeetingInstant(
+      now,
+      4,
+      11,
+      30,
+      winterBaseDate,
+      undefined
+    )
 
     // 11:30am ET during EST (UTC-5) -> 4:30pm UTC, not the 3:30pm EDT would give.
     expect(instant?.toISOString()).toBe("2027-01-07T16:30:00.000Z")
@@ -120,8 +145,7 @@ describe("main", () => {
     process.env = {
       ...originalEnv,
       GITHUB_OUTPUT: undefined,
-      DATES: JSON.stringify(REAL_SCHEDULE),
-      MEETING_LOOKAHEAD_DAYS: "1",
+      MEETING_BASE_DATE: BASE_DATE,
     }
     mockCurrentOnCallUsers.mockResolvedValue([{ id: "user-1" }])
     mockUsersToMentions.mockReturnValue(["<@U_ALICE>"])
@@ -149,41 +173,17 @@ describe("main", () => {
     await expect(main()).rejects.toThrow("SCHEDULE_ID env var is not set.")
   })
 
-  it("throws when MEETING_LOOKAHEAD_DAYS is not set", async () => {
+  it("throws when MEETING_BASE_DATE is not set", async () => {
     process.env.INCIDENT_IO_API_KEY = "test-key"
     process.env.SCHEDULE_ID = "schedule-123"
-    delete process.env.MEETING_LOOKAHEAD_DAYS
+    delete process.env.MEETING_BASE_DATE
 
     await expect(main()).rejects.toThrow(
-      "MEETING_LOOKAHEAD_DAYS env var is not set."
+      "MEETING_BASE_DATE env var is not set."
     )
   })
 
-  it("throws when DATES is not set", async () => {
-    process.env.INCIDENT_IO_API_KEY = "test-key"
-    process.env.SCHEDULE_ID = "schedule-123"
-    delete process.env.DATES
-
-    await expect(main()).rejects.toThrow("DATES env var is not set.")
-  })
-
-  it("throws when DATES is malformed JSON", async () => {
-    process.env.INCIDENT_IO_API_KEY = "test-key"
-    process.env.SCHEDULE_ID = "schedule-123"
-    process.env.DATES = "not json"
-
-    await expect(main()).rejects.toThrow("Invalid DATES env var")
-  })
-
-  it("throws when DATES is missing required fields", async () => {
-    process.env.INCIDENT_IO_API_KEY = "test-key"
-    process.env.SCHEDULE_ID = "schedule-123"
-    process.env.DATES = JSON.stringify({ baseDate: "2023-04-27" })
-
-    await expect(main()).rejects.toThrow("Invalid DATES env var")
-  })
-
-  it("throws when DATES.baseDate's weekday doesn't match MEETING_WEEKDAY", async () => {
+  it("throws when MEETING_BASE_DATE's weekday doesn't match MEETING_WEEKDAY", async () => {
     process.env.INCIDENT_IO_API_KEY = "test-key"
     process.env.SCHEDULE_ID = "schedule-123"
     // 2023-04-27 is a Thursday (weekday 4); configuring Wednesday (3) here
@@ -191,11 +191,11 @@ describe("main", () => {
     process.env.MEETING_WEEKDAY = "3"
 
     await expect(main()).rejects.toThrow(
-      'DATES.baseDate ("2023-04-27") falls on weekday 4, but MEETING_WEEKDAY is 3'
+      'MEETING_BASE_DATE ("2023-04-27") falls on weekday 4, but MEETING_WEEKDAY is 3'
     )
   })
 
-  it("logs and skips without writing GITHUB_OUTPUT on an off-week with no exception", async () => {
+  it("logs and skips without writing GITHUB_OUTPUT on an off-week with no override", async () => {
     jest.setSystemTime(new Date("2026-07-22T14:00:00Z")) // off-week Wednesday
     process.env.INCIDENT_IO_API_KEY = "test-key"
     process.env.SCHEDULE_ID = "schedule-123"
@@ -204,7 +204,9 @@ describe("main", () => {
 
     await main()
 
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("skipping"))
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("skipping")
+    )
     expect(mockFs.appendFileSync).not.toHaveBeenCalled()
     expect(mockCurrentOnCallUsers).not.toHaveBeenCalled()
     consoleSpy.mockRestore()
@@ -226,6 +228,23 @@ describe("main", () => {
     )
     const [, contents] = mockFs.appendFileSync.mock.calls[0]
     expect(contents).toContain("<@U_ALICE>")
+  })
+
+  it("uses MEETING_OVERRIDE_DATE for a manual catch-up run on an off-week", async () => {
+    jest.setSystemTime(new Date("2026-07-20T14:00:00Z")) // well before the catch-up
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.GITHUB_OUTPUT = "/tmp/fake-output"
+    process.env.MEETING_OVERRIDE_DATE = "2026-07-23" // an off-week Thursday
+    mockFs.appendFileSync.mockImplementation(() => undefined)
+
+    await main()
+
+    expect(mockCurrentOnCallUsers).toHaveBeenCalledWith(
+      "test-key",
+      "schedule-123",
+      new Date("2026-07-23T15:30:00.000Z")
+    )
   })
 
   it("still posts a warning payload when nobody on-call is mentionable", async () => {

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -34,13 +34,16 @@ describe("buildPayload", () => {
     expect(text).toContain("Incident Review Schedule")
   })
 
-  it("posts a warning instead of an empty mention when nobody is mentionable", () => {
+  it("posts a cause-agnostic warning instead of an empty mention when nobody is mentionable", () => {
+    // Could mean a schedule gap OR everyone lacking a linked Slack account --
+    // the message shouldn't claim which one it is.
     const payload = JSON.parse(buildPayload(undefined, SCHEDULE_URL))
 
     expect(payload.blocks).toHaveLength(1)
     const text = payload.blocks[0].text.text
     expect(text).toContain(":warning:")
-    expect(text).toContain("can be reached on Slack")
+    expect(text).toContain("No one appears to be reachable on Slack")
+    expect(text).not.toContain("no linked account")
     expect(text).toContain(`<${SCHEDULE_URL}|on-call schedule>`)
   })
 })
@@ -143,6 +146,33 @@ describe("resolveMeetingInstant", () => {
     expect(() =>
       resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, "2026-07-23")
     ).toThrow("is not after now")
+  })
+
+  it("throws when the override date is more than 60 days out (e.g. a year typo)", () => {
+    // A wrong year (2027 instead of 2026) passes the past-date check but
+    // would leave the real, near-term meeting without a facilitator.
+    const now = new Date("2026-07-24T14:00:00Z")
+
+    expect(() =>
+      resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, "2027-07-23")
+    ).toThrow(
+      'MEETING_OVERRIDE_DATE "2027-07-23" resolves to 2027-07-23T15:30:00.000Z, which is more than 60 days from now (2026-07-24T14:00:00.000Z). Double-check the year — this is meant for a near-term catch-up, not a far-future date.'
+    )
+  })
+
+  it("allows an override date right at the 60-day boundary", () => {
+    const now = new Date("2026-07-24T14:00:00Z")
+    // Thursday, exactly 56 days out (8 weeks), within the 60-day ceiling.
+    const instant = resolveMeetingInstant(
+      now,
+      4,
+      11,
+      30,
+      BASE_DATE,
+      "2026-09-17"
+    )
+
+    expect(instant?.toISOString()).toBe("2026-09-17T15:30:00.000Z")
   })
 
   it("throws on a malformed override date", () => {
@@ -307,6 +337,23 @@ describe("main", () => {
       "test-key",
       "schedule-123",
       new Date("2026-07-23T15:30:00.000Z")
+    )
+  })
+
+  it("treats a whitespace-only MEETING_OVERRIDE_DATE as unset, falling through to the routine path", async () => {
+    jest.setSystemTime(new Date("2026-07-15T14:00:00Z")) // on-week Wednesday
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.GITHUB_OUTPUT = "/tmp/fake-output"
+    process.env.MEETING_OVERRIDE_DATE = "   " // e.g. a blank workflow_dispatch input
+    mockFs.appendFileSync.mockImplementation(() => undefined)
+
+    await main()
+
+    expect(mockCurrentOnCallUsers).toHaveBeenCalledWith(
+      "test-key",
+      "schedule-123",
+      new Date("2026-07-16T15:30:00.000Z")
     )
   })
 

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -5,6 +5,7 @@ import {
   resolveMeetingInstant,
 } from "./facilitate-incident-review"
 import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
+import { MS_PER_DAY } from "./shift-boundary"
 
 jest.mock("fs")
 jest.mock("./incident-io")
@@ -160,9 +161,9 @@ describe("resolveMeetingInstant", () => {
     )
   })
 
-  it("allows an override date right at the 60-day boundary", () => {
+  it("allows an override date comfortably within the 60-day ceiling", () => {
     const now = new Date("2026-07-24T14:00:00Z")
-    // Thursday, exactly 56 days out (8 weeks), within the 60-day ceiling.
+    // 55 days out -- well short of the 60-day ceiling.
     const instant = resolveMeetingInstant(
       now,
       4,
@@ -173,6 +174,33 @@ describe("resolveMeetingInstant", () => {
     )
 
     expect(instant?.toISOString()).toBe("2026-09-17T15:30:00.000Z")
+  })
+
+  it("allows an override date resolving to exactly the 60-day ceiling", () => {
+    // now is set to 11:30am ET (EDT, UTC-4) so that adding exactly 60 days
+    // lands on the override's own 11:30am ET instant -- both dates are
+    // before the November DST fall-back, so the offset stays constant and
+    // the two instants line up to the millisecond.
+    const now = new Date("2026-07-24T15:30:00.000Z")
+
+    const instant = resolveMeetingInstant(
+      now,
+      4,
+      11,
+      30,
+      BASE_DATE,
+      "2026-09-22"
+    )
+
+    expect(instant?.getTime()).toBe(now.getTime() + 60 * MS_PER_DAY)
+  })
+
+  it("throws for an override date one day past the 60-day ceiling", () => {
+    const now = new Date("2026-07-24T15:30:00.000Z")
+
+    expect(() =>
+      resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, "2026-09-23")
+    ).toThrow("is more than 60 days from now")
   })
 
   it("throws on a malformed override date", () => {
@@ -297,6 +325,38 @@ describe("main", () => {
 
     await expect(main()).rejects.toThrow(
       'Invalid MEETING_BASE_DATE: "2026-02-31" is not a real calendar date.'
+    )
+  })
+
+  it("does not validate MEETING_BASE_DATE's weekday when a manual override is set", async () => {
+    // baseDate/meetingWeekday are mismatched (same as the throwing test
+    // above), but that check has no bearing on the override path, which
+    // never uses baseDate at all.
+    jest.setSystemTime(new Date("2026-07-20T14:00:00Z"))
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.GITHUB_OUTPUT = "/tmp/fake-output"
+    process.env.MEETING_WEEKDAY = "3"
+    process.env.MEETING_OVERRIDE_DATE = "2026-07-23"
+    mockFs.appendFileSync.mockImplementation(() => undefined)
+
+    await main()
+
+    expect(mockCurrentOnCallUsers).toHaveBeenCalledWith(
+      "test-key",
+      "schedule-123",
+      new Date("2026-07-23T15:30:00.000Z")
+    )
+  })
+
+  it("still requires MEETING_BASE_DATE to be present even with a manual override set", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.MEETING_OVERRIDE_DATE = "2026-07-23"
+    delete process.env.MEETING_BASE_DATE
+
+    await expect(main()).rejects.toThrow(
+      "MEETING_BASE_DATE env var is not set."
     )
   })
 

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -68,13 +68,16 @@ describe("resolveMeetingInstant", () => {
 
   it("throws when tomorrow isn't meetingWeekday at all", () => {
     // Any day where tomorrow isn't Thursday -- a real misconfiguration
-    // (cron/meetingWeekday mismatch), not the legitimate off-week case.
+    // (cron/meetingWeekday mismatch), not the legitimate off-week case. The
+    // message also points at MEETING_OVERRIDE_DATE, since this can equally
+    // fire during a manual workflow_dispatch test run where "check the cron
+    // schedule" isn't useful advice.
     const now = new Date("2026-07-16T14:00:00Z") // tomorrow is Friday
 
     expect(() =>
       resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, undefined)
     ).toThrow(
-      "resolveMeetingInstant expected tomorrow (in America/New_York) to be weekday 4, but it's 5."
+      "resolveMeetingInstant expected tomorrow (in America/New_York) to be weekday 4, but it's 5. Check the cron schedule against MEETING_WEEKDAY, or set MEETING_OVERRIDE_DATE to target a specific date directly."
     )
   })
 
@@ -150,6 +153,21 @@ describe("resolveMeetingInstant", () => {
     ).toThrow(
       'Invalid MEETING_OVERRIDE_DATE: "07/27/2026". Must be YYYY-MM-DD.'
     )
+  })
+
+  it("tolerates leading/trailing whitespace in a hand-typed override date", () => {
+    const now = new Date("2026-07-24T14:00:00Z")
+
+    const instant = resolveMeetingInstant(
+      now,
+      4,
+      11,
+      30,
+      BASE_DATE,
+      " 2026-07-27 "
+    )
+
+    expect(instant?.toISOString()).toBe("2026-07-27T15:30:00.000Z")
   })
 
   it("throws on an override date that doesn't exist on the calendar", () => {

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -17,8 +17,9 @@ const mockScheduleUrl = scheduleUrl as jest.Mock
 const SCHEDULE_URL =
   "https://app.incident.io/artsy/on-call/schedules/schedule-123"
 
-// A real joule repo var; 2026-07-16 confirmed by the user as a real
-// Incident Review day, 2026-07-23/2026-07-22 confirmed off-week.
+// A real joule repo var (2023-04-27); 2026-07-16 is a real Incident Review
+// day (168 weeks out — even, so on-week); 2026-07-23/2026-07-22 are 169
+// weeks out (odd, so off-week).
 const BASE_DATE = "2023-04-27"
 
 describe("buildPayload", () => {

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -139,7 +139,7 @@ describe("resolveMeetingInstant", () => {
 
     expect(() =>
       resolveMeetingInstant(now, 4, 11, 30, BASE_DATE, "2026-07-23")
-    ).toThrow('is not after now')
+    ).toThrow("is not after now")
   })
 
   it("throws on a malformed override date", () => {
@@ -251,9 +251,7 @@ describe("main", () => {
 
     await main()
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("skipping")
-    )
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("skipping"))
     expect(mockFs.appendFileSync).not.toHaveBeenCalled()
     expect(mockCurrentOnCallUsers).not.toHaveBeenCalled()
     consoleSpy.mockRestore()

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -290,6 +290,16 @@ describe("main", () => {
     )
   })
 
+  it("throws a clear format error for a malformed MEETING_BASE_DATE, not a confusing weekday NaN", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.MEETING_BASE_DATE = "2026-02-31" // doesn't exist on the calendar
+
+    await expect(main()).rejects.toThrow(
+      'Invalid MEETING_BASE_DATE: "2026-02-31" is not a real calendar date.'
+    )
+  })
+
   it("logs and skips without writing GITHUB_OUTPUT on an off-week with no override", async () => {
     jest.setSystemTime(new Date("2026-07-22T14:00:00Z")) // off-week Wednesday
     process.env.INCIDENT_IO_API_KEY = "test-key"

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -1,0 +1,246 @@
+import * as fs from "fs"
+import { type BiweeklySchedule } from "./biweekly"
+import {
+  buildPayload,
+  findMeetingInstant,
+  main,
+} from "./facilitate-incident-review"
+import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
+
+jest.mock("fs")
+jest.mock("./incident-io")
+
+const mockFs = fs as jest.Mocked<typeof fs>
+const mockCurrentOnCallUsers = currentOnCallUsers as jest.Mock
+const mockUsersToMentions = usersToMentions as jest.Mock
+const mockScheduleUrl = scheduleUrl as jest.Mock
+
+const SCHEDULE_URL =
+  "https://app.incident.io/artsy/on-call/schedules/schedule-123"
+
+// Real joule DATES repo var; 2026-07-16 confirmed by the user as a real
+// Incident Review day, 2026-07-23/2026-07-22 confirmed off-week.
+const REAL_SCHEDULE: BiweeklySchedule = {
+  baseDate: "2023-04-27",
+  exceptions: [],
+}
+
+describe("buildPayload", () => {
+  it("mentions the chosen facilitator and links the schedule + review doc", () => {
+    const payload = JSON.parse(buildPayload("<@U_ALICE>", SCHEDULE_URL))
+
+    expect(payload.blocks).toHaveLength(1)
+    const text = payload.blocks[0].text.text
+    expect(text).toContain("<@U_ALICE> :wave:")
+    expect(text).toContain(`<${SCHEDULE_URL}|on-call schedule>`)
+    expect(text).toContain("facilitate_ the upcoming Incident Review meeting")
+    expect(text).toContain("Incident Review Schedule")
+  })
+
+  it("posts a warning instead of an empty mention when nobody is mentionable", () => {
+    const payload = JSON.parse(buildPayload(undefined, SCHEDULE_URL))
+
+    expect(payload.blocks).toHaveLength(1)
+    const text = payload.blocks[0].text.text
+    expect(text).toContain(":warning:")
+    expect(text).toContain("can be reached on Slack")
+    expect(text).toContain(`<${SCHEDULE_URL}|on-call schedule>`)
+  })
+})
+
+describe("findMeetingInstant", () => {
+  it("finds tomorrow's on-week Thursday meeting with a 1-day cron lookahead", () => {
+    // Wednesday 2026-07-15, an on-week per the real baseDate; the cron only
+    // ever needs to see 1 day ahead.
+    const now = new Date("2026-07-15T14:00:00Z")
+
+    const instant = findMeetingInstant(now, 4, 11, 30, REAL_SCHEDULE, 1)
+
+    // 2026-07-16 is EDT (UTC-4): 11:30am ET -> 3:30pm UTC.
+    expect(instant?.toISOString()).toBe("2026-07-16T15:30:00.000Z")
+  })
+
+  it("returns null on an off-week with a 1-day cron lookahead and no exception", () => {
+    // Wednesday 2026-07-22, an off-week; tomorrow (2026-07-23) has no review.
+    const now = new Date("2026-07-22T14:00:00Z")
+
+    const instant = findMeetingInstant(now, 4, 11, 30, REAL_SCHEDULE, 1)
+
+    expect(instant).toBeNull()
+  })
+
+  it("finds a Monday catch-up exception with a wider manual-trigger lookahead", () => {
+    // Friday 2026-07-24, an off-week catch-up scheduled for Monday
+    // 2026-07-27 (a weekday that doesn't match the regular Thursday cadence
+    // at all) -- triggered 3 days ahead, within a 6-day manual lookahead.
+    const now = new Date("2026-07-24T14:00:00Z")
+    const schedule: BiweeklySchedule = {
+      ...REAL_SCHEDULE,
+      exceptions: ["2026-07-27"],
+    }
+
+    const instant = findMeetingInstant(now, 4, 11, 30, schedule, 6)
+
+    // 2026-07-27 is still EDT: 11:30am ET -> 3:30pm UTC.
+    expect(instant?.toISOString()).toBe("2026-07-27T15:30:00.000Z")
+  })
+
+  it("returns null when nothing qualifies within the lookahead window", () => {
+    // Same off-week Friday, but no exception configured and the lookahead
+    // stays short of reaching any on-week Thursday.
+    const now = new Date("2026-07-24T14:00:00Z")
+
+    const instant = findMeetingInstant(now, 4, 11, 30, REAL_SCHEDULE, 3)
+
+    expect(instant).toBeNull()
+  })
+
+  it("resolves the meeting hour/minute DST-aware for the candidate's own date", () => {
+    // baseDate === the candidate itself, so weeksSince = 0 (on-week),
+    // isolating this test from the real production parity data.
+    const winterSchedule: BiweeklySchedule = {
+      baseDate: "2027-01-07", // Thursday, EST (UTC-5)
+      exceptions: [],
+    }
+    const now = new Date("2027-01-06T14:00:00Z") // Wednesday before
+
+    const instant = findMeetingInstant(now, 4, 11, 30, winterSchedule, 1)
+
+    // 11:30am ET during EST (UTC-5) -> 4:30pm UTC, not the 3:30pm EDT would give.
+    expect(instant?.toISOString()).toBe("2027-01-07T16:30:00.000Z")
+  })
+})
+
+describe("main", () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    process.env = {
+      ...originalEnv,
+      GITHUB_OUTPUT: undefined,
+      DATES: JSON.stringify(REAL_SCHEDULE),
+      MEETING_LOOKAHEAD_DAYS: "1",
+    }
+    mockCurrentOnCallUsers.mockResolvedValue([{ id: "user-1" }])
+    mockUsersToMentions.mockReturnValue(["<@U_ALICE>"])
+    mockScheduleUrl.mockReturnValue(SCHEDULE_URL)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    jest.useRealTimers()
+  })
+
+  it("throws when INCIDENT_IO_API_KEY is not set", async () => {
+    delete process.env.INCIDENT_IO_API_KEY
+    process.env.SCHEDULE_ID = "schedule-123"
+
+    await expect(main()).rejects.toThrow(
+      "INCIDENT_IO_API_KEY env var is not set."
+    )
+  })
+
+  it("throws when SCHEDULE_ID is not set", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    delete process.env.SCHEDULE_ID
+
+    await expect(main()).rejects.toThrow("SCHEDULE_ID env var is not set.")
+  })
+
+  it("throws when MEETING_LOOKAHEAD_DAYS is not set", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    delete process.env.MEETING_LOOKAHEAD_DAYS
+
+    await expect(main()).rejects.toThrow(
+      "MEETING_LOOKAHEAD_DAYS env var is not set."
+    )
+  })
+
+  it("throws when DATES is not set", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    delete process.env.DATES
+
+    await expect(main()).rejects.toThrow("DATES env var is not set.")
+  })
+
+  it("throws when DATES is malformed JSON", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.DATES = "not json"
+
+    await expect(main()).rejects.toThrow("Invalid DATES env var")
+  })
+
+  it("throws when DATES is missing required fields", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.DATES = JSON.stringify({ baseDate: "2023-04-27" })
+
+    await expect(main()).rejects.toThrow("Invalid DATES env var")
+  })
+
+  it("logs and skips without writing GITHUB_OUTPUT on an off-week with no exception", async () => {
+    jest.setSystemTime(new Date("2026-07-22T14:00:00Z")) // off-week Wednesday
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.GITHUB_OUTPUT = "/tmp/fake-output"
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("skipping"))
+    expect(mockFs.appendFileSync).not.toHaveBeenCalled()
+    expect(mockCurrentOnCallUsers).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+
+  it("queries on-call at the meeting instant and posts the facilitator payload", async () => {
+    jest.setSystemTime(new Date("2026-07-15T14:00:00Z")) // on-week Wednesday
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.GITHUB_OUTPUT = "/tmp/fake-output"
+    mockFs.appendFileSync.mockImplementation(() => undefined)
+
+    await main()
+
+    expect(mockCurrentOnCallUsers).toHaveBeenCalledWith(
+      "test-key",
+      "schedule-123",
+      new Date("2026-07-16T15:30:00.000Z")
+    )
+    const [, contents] = mockFs.appendFileSync.mock.calls[0]
+    expect(contents).toContain("<@U_ALICE>")
+  })
+
+  it("still posts a warning payload when nobody on-call is mentionable", async () => {
+    jest.setSystemTime(new Date("2026-07-15T14:00:00Z"))
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    process.env.GITHUB_OUTPUT = "/tmp/fake-output"
+    mockUsersToMentions.mockReturnValue([])
+    mockFs.appendFileSync.mockImplementation(() => undefined)
+
+    await main()
+
+    expect(mockFs.appendFileSync).toHaveBeenCalledTimes(1)
+    const [, contents] = mockFs.appendFileSync.mock.calls[0]
+    expect(contents).toContain(":warning:")
+  })
+
+  it("logs the payload to stdout when GITHUB_OUTPUT is unset", async () => {
+    jest.setSystemTime(new Date("2026-07-15T14:00:00Z"))
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation()
+
+    await main()
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    expect(consoleSpy.mock.calls[0][0]).toContain("<@U_ALICE>")
+    consoleSpy.mockRestore()
+  })
+})

--- a/scripts/on-call/facilitate-incident-review.test.ts
+++ b/scripts/on-call/facilitate-incident-review.test.ts
@@ -183,6 +183,18 @@ describe("main", () => {
     await expect(main()).rejects.toThrow("Invalid DATES env var")
   })
 
+  it("throws when DATES.baseDate's weekday doesn't match MEETING_WEEKDAY", async () => {
+    process.env.INCIDENT_IO_API_KEY = "test-key"
+    process.env.SCHEDULE_ID = "schedule-123"
+    // 2023-04-27 is a Thursday (weekday 4); configuring Wednesday (3) here
+    // simulates the meeting day changing without baseDate being updated.
+    process.env.MEETING_WEEKDAY = "3"
+
+    await expect(main()).rejects.toThrow(
+      'DATES.baseDate ("2023-04-27") falls on weekday 4, but MEETING_WEEKDAY is 3'
+    )
+  })
+
   it("logs and skips without writing GITHUB_OUTPUT on an off-week with no exception", async () => {
     jest.setSystemTime(new Date("2026-07-22T14:00:00Z")) // off-week Wednesday
     process.env.INCIDENT_IO_API_KEY = "test-key"

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -14,6 +14,14 @@ const DEFAULT_MEETING_WEEKDAY = 4 // Thursday
 const DEFAULT_MEETING_HOUR = 11 // 11:30am ET (DST-aware via zonedTimeToUtc)
 const DEFAULT_MEETING_MINUTE = 30
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+// Catch-ups are a near-term, days-to-weeks-out scenario — never months away —
+// so this also catches a hand-typed year typo (e.g. 2027 instead of 2026)
+// that the past-date check alone can't, since a typo in the future direction
+// still passes that check but would silently leave the real, near-term
+// meeting without a facilitator.
+const MAX_OVERRIDE_DAYS_AHEAD = 60
+
 const URLS = {
   incidentReviewSchedule:
     "https://www.notion.so/artsy/Incident-Reviews-725052225efc49e78532b13e166ba3c7",
@@ -29,7 +37,7 @@ export const buildPayload = (
   // silent.
   const text = mention
     ? `${mention} :wave:, based on the <${onCallScheduleUrl}|on-call schedule> you've been selected to _prepare for and facilitate_ the upcoming Incident Review meeting! :tada:\nCheck out the <${URLS.incidentReviewSchedule}|Incident Review Schedule> for more information and the next steps.`
-    : `:warning: A facilitator should be picked for the upcoming Incident Review meeting, but nobody on the <${onCallScheduleUrl}|on-call schedule> can be reached on Slack (no linked account).`
+    : `:warning: No one appears to be reachable on Slack according to our <${onCallScheduleUrl}|on-call schedule> — please make sure someone facilitates the upcoming Incident Review meeting.`
 
   return JSON.stringify({
     blocks: [
@@ -81,7 +89,10 @@ const parseOverrideDate = (
 // the biweekly on/off-week check entirely. Throws if it resolves to an
 // instant that isn't strictly in the future, since a past override would
 // otherwise silently query on-call for, and post a facilitator notice about,
-// a meeting that's already happened.
+// a meeting that's already happened. Also throws if it's more than
+// `MAX_OVERRIDE_DAYS_AHEAD` out, since a hand-typed year typo in the future
+// direction (e.g. 2027 instead of 2026) would otherwise pass the past-date
+// check but still leave the real, near-term meeting without a facilitator.
 //
 // Otherwise, this is the routine cron path: it always runs the day before
 // the meeting, in `timeZone` civil time. "Tomorrow" is computed via
@@ -119,6 +130,15 @@ export const resolveMeetingInstant = (
     if (overrideInstant.getTime() <= now.getTime()) {
       throw new Error(
         `MEETING_OVERRIDE_DATE "${overrideDate}" resolves to ${overrideInstant.toISOString()}, which is not after now (${now.toISOString()}). The override must target a future meeting.`
+      )
+    }
+
+    const maxOverrideInstant = new Date(
+      now.getTime() + MAX_OVERRIDE_DAYS_AHEAD * MS_PER_DAY
+    )
+    if (overrideInstant.getTime() > maxOverrideInstant.getTime()) {
+      throw new Error(
+        `MEETING_OVERRIDE_DATE "${overrideDate}" resolves to ${overrideInstant.toISOString()}, which is more than ${MAX_OVERRIDE_DAYS_AHEAD} days from now (${now.toISOString()}). Double-check the year — this is meant for a near-term catch-up, not a far-future date.`
       )
     }
 
@@ -193,7 +213,10 @@ export const main = async (): Promise<void> => {
   const baseDate = requireEnv("MEETING_BASE_DATE")
   requireBaseDateMatchesMeetingWeekday(baseDate, meetingWeekday)
   // Only set for a rare manual catch-up run — see resolveMeetingInstant.
-  const overrideDate = process.env.MEETING_OVERRIDE_DATE || undefined
+  // Trimmed before the truthiness check so a whitespace-only value (e.g. a
+  // blank workflow_dispatch input) falls through to the routine path
+  // instead of being treated as "an override is set."
+  const overrideDate = process.env.MEETING_OVERRIDE_DATE?.trim() || undefined
 
   const meetingInstant = resolveMeetingInstant(
     new Date(),

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs"
 
 import { isOffWeek } from "./biweekly"
+import { readIntEnv, requireEnv } from "./env"
 import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
 import {
   civilDatePlusDays,
@@ -138,31 +139,6 @@ export const resolveMeetingInstant = (
     0,
     timeZone
   )
-}
-
-const requireEnv = (name: string): string => {
-  const value = process.env[name]
-  if (!value) {
-    throw new Error(`${name} env var is not set.`)
-  }
-  return value
-}
-
-const readIntEnv = (
-  name: string,
-  defaultValue: number,
-  range: { min: number; max: number }
-): number => {
-  const raw = process.env[name]
-  const value = raw ? Number.parseInt(raw, 10) : defaultValue
-
-  if (Number.isNaN(value) || value < range.min || value > range.max) {
-    throw new Error(
-      `Invalid ${name}: "${raw}". Must be an integer between ${range.min} and ${range.max}.`
-    )
-  }
-
-  return value
 }
 
 // isOffWeek's parity math assumes `baseDate` and any date it's compared

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -52,34 +52,34 @@ export const buildPayload = (
   })
 }
 
-const OVERRIDE_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+const CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 
-const parseOverrideDate = (
+// Validates a hand-typed YYYY-MM-DD env var, shared by MEETING_OVERRIDE_DATE
+// and MEETING_BASE_DATE since both are hand-typed the same way and deserve
+// the same failure mode. Date.UTC silently rolls over out-of-range values
+// (e.g. Feb 31 becomes Mar 3) instead of rejecting them — round-tripping
+// back to a string catches a typo the regex above can't.
+const parseCalendarDate = (
+  envVarName: string,
   raw: string
-): { year: number; month: number; day: number } => {
+): { year: number; month: number; day: number; canonical: string } => {
   const trimmed = raw.trim()
-  if (!OVERRIDE_DATE_PATTERN.test(trimmed)) {
-    throw new Error(
-      `Invalid MEETING_OVERRIDE_DATE: "${raw}". Must be YYYY-MM-DD.`
-    )
+  if (!CALENDAR_DATE_PATTERN.test(trimmed)) {
+    throw new Error(`Invalid ${envVarName}: "${raw}". Must be YYYY-MM-DD.`)
   }
   const [year, month, day] = trimmed.split("-").map(Number)
 
-  // Date.UTC silently rolls over out-of-range values (e.g. Feb 31 becomes
-  // Mar 3) instead of rejecting them — round-tripping back to a string
-  // catches a typo in this hand-typed, workflow_dispatch-entered value that
-  // the regex above can't.
   const roundTrip = new Date(Date.UTC(year, month - 1, day))
   const roundTripString = `${roundTrip.getUTCFullYear()}-${String(
     roundTrip.getUTCMonth() + 1
   ).padStart(2, "0")}-${String(roundTrip.getUTCDate()).padStart(2, "0")}`
   if (roundTripString !== trimmed) {
     throw new Error(
-      `Invalid MEETING_OVERRIDE_DATE: "${raw}" is not a real calendar date.`
+      `Invalid ${envVarName}: "${raw}" is not a real calendar date.`
     )
   }
 
-  return { year, month, day }
+  return { year, month, day, canonical: trimmed }
 }
 
 // Resolves the instant to query on-call at.
@@ -116,7 +116,10 @@ export const resolveMeetingInstant = (
   timeZone: string = DEFAULT_TIME_ZONE
 ): Date | null => {
   if (overrideDate) {
-    const { year, month, day } = parseOverrideDate(overrideDate)
+    const { year, month, day } = parseCalendarDate(
+      "MEETING_OVERRIDE_DATE",
+      overrideDate
+    )
     const overrideInstant = zonedTimeToUtc(
       year,
       month,
@@ -173,6 +176,12 @@ export const resolveMeetingInstant = (
   )
 }
 
+// Validates MEETING_BASE_DATE's format (the same hand-typed YYYY-MM-DD check
+// as MEETING_OVERRIDE_DATE — without it, a malformed value like "2026-02-31"
+// produces a confusing "falls on weekday NaN" error instead of a clear
+// format complaint) and returns the canonical (trimmed) string to use
+// downstream.
+//
 // isOffWeek's parity math assumes `baseDate` and any date it's compared
 // against fall on the same weekday, so they're always an exact multiple of
 // 7 days apart (see the comment on isOffWeek in biweekly.ts). That's only
@@ -181,17 +190,23 @@ export const resolveMeetingInstant = (
 // enforce on their own. Fail loudly here rather than silently computing the
 // wrong on/off-week parity if the meeting day ever changes without updating
 // baseDate to match.
-const requireBaseDateMatchesMeetingWeekday = (
-  baseDate: string,
+const requireValidBaseDate = (
+  rawBaseDate: string,
   meetingWeekday: number
-): void => {
-  const baseDateWeekday = new Date(`${baseDate}T00:00:00Z`).getUTCDay()
+): string => {
+  const { year, month, day, canonical } = parseCalendarDate(
+    "MEETING_BASE_DATE",
+    rawBaseDate
+  )
+  const baseDateWeekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay()
 
   if (baseDateWeekday !== meetingWeekday) {
     throw new Error(
-      `MEETING_BASE_DATE ("${baseDate}") falls on weekday ${baseDateWeekday}, but MEETING_WEEKDAY is ${meetingWeekday}. baseDate must fall on the same weekday as the configured meeting day — if the meeting day changed, update baseDate to a date on the new weekday too.`
+      `MEETING_BASE_DATE ("${canonical}") falls on weekday ${baseDateWeekday}, but MEETING_WEEKDAY is ${meetingWeekday}. baseDate must fall on the same weekday as the configured meeting day — if the meeting day changed, update baseDate to a date on the new weekday too.`
     )
   }
+
+  return canonical
 }
 
 export const main = async (): Promise<void> => {
@@ -210,8 +225,10 @@ export const main = async (): Promise<void> => {
     min: 0,
     max: 59,
   })
-  const baseDate = requireEnv("MEETING_BASE_DATE")
-  requireBaseDateMatchesMeetingWeekday(baseDate, meetingWeekday)
+  const baseDate = requireValidBaseDate(
+    requireEnv("MEETING_BASE_DATE"),
+    meetingWeekday
+  )
   // Only set for a rare manual catch-up run — see resolveMeetingInstant.
   // Trimmed before the truthiness check so a whitespace-only value (e.g. a
   // blank workflow_dispatch input) falls through to the routine path

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -198,6 +198,9 @@ export const main = async (): Promise<void> => {
 
   const users = await currentOnCallUsers(apiKey, scheduleId, meetingInstant)
   const mentions = usersToMentions(users)
+  console.log(
+    `facilitate-incident-review: choosing a facilitator from ${mentions.length} on-call participant(s): ${mentions.join(", ") || "none"}`
+  )
   const facilitatorMention =
     mentions.length > 0
       ? mentions[Math.floor(Math.random() * mentions.length)]

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -15,11 +15,8 @@ const DEFAULT_MEETING_WEEKDAY = 4 // Thursday
 const DEFAULT_MEETING_HOUR = 11 // 11:30am ET (DST-aware via zonedTimeToUtc)
 const DEFAULT_MEETING_MINUTE = 30
 
-// Catch-ups are a near-term, days-to-weeks-out scenario — never months away —
-// so this also catches a hand-typed year typo (e.g. 2027 instead of 2026)
-// that the past-date check alone can't, since a typo in the future direction
-// still passes that check but would silently leave the real, near-term
-// meeting without a facilitator.
+// Catches a future-direction year typo (e.g. 2027 for 2026) that the
+// past-date check alone can't.
 const MAX_OVERRIDE_DAYS_AHEAD = 60
 
 const URLS = {
@@ -31,10 +28,8 @@ export const buildPayload = (
   mention: string | undefined,
   onCallScheduleUrl: string
 ): string => {
-  // currentOnCallUsers/usersToMentions can legitimately return nobody
-  // mentionable (a schedule gap, or every on-call participant missing a
-  // linked Slack account) — post an explicit notice instead of staying
-  // silent.
+  // A schedule gap or missing Slack links can mean nobody's mentionable —
+  // post an explicit notice instead of staying silent.
   const text = mention
     ? `${mention} :wave:, based on the <${onCallScheduleUrl}|on-call schedule> you've been selected to _prepare for and facilitate_ the upcoming Incident Review meeting! :tada:\nCheck out the <${URLS.incidentReviewSchedule}|Incident Review Schedule> for more information and the next steps.`
     : `:warning: No one appears to be reachable on Slack according to our <${onCallScheduleUrl}|on-call schedule> — please make sure someone facilitates the upcoming Incident Review meeting.`
@@ -54,11 +49,9 @@ export const buildPayload = (
 
 const CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 
-// Validates a hand-typed YYYY-MM-DD env var, shared by MEETING_OVERRIDE_DATE
-// and MEETING_BASE_DATE since both are hand-typed the same way and deserve
-// the same failure mode. Date.UTC silently rolls over out-of-range values
-// (e.g. Feb 31 becomes Mar 3) instead of rejecting them — round-tripping
-// back to a string catches a typo the regex above can't.
+// Shared by MEETING_OVERRIDE_DATE and MEETING_BASE_DATE. Round-trips through
+// Date.UTC to catch calendar-invalid dates (e.g. Feb 31) the regex alone
+// would miss.
 const parseCalendarDate = (
   envVarName: string,
   raw: string
@@ -82,30 +75,15 @@ const parseCalendarDate = (
   return { year, month, day, canonical: trimmed }
 }
 
-// Resolves the instant to query on-call at.
-//
-// If `overrideDate` is supplied (a rare manual catch-up run), targets that
-// date directly — an explicit override always means "run now," bypassing
-// the biweekly on/off-week check entirely. Throws if it resolves to an
-// instant that isn't strictly in the future, since a past override would
-// otherwise silently query on-call for, and post a facilitator notice about,
-// a meeting that's already happened. Also throws if it's more than
-// `MAX_OVERRIDE_DAYS_AHEAD` out, since a hand-typed year typo in the future
-// direction (e.g. 2027 instead of 2026) would otherwise pass the past-date
-// check but still leave the real, near-term meeting without a facilitator.
-//
-// Otherwise, this is the routine cron path: it always runs the day before
-// the meeting, in `timeZone` civil time. "Tomorrow" is computed via
-// `civilDateTimeIn`/`civilDatePlusDays` rather than raw UTC arithmetic,
-// because a cron's UTC firing instant can already be on a different UTC
-// calendar date than its `timeZone` civil date (e.g. a cron meant for
-// "Wednesday evening ET" fires at 2am UTC Thursday) — naive UTC-day-plus-one
-// would compound that offset instead of correcting for it. Throws if
-// tomorrow isn't `meetingWeekday` at all — the same class of misconfigured
-// cron-vs-boundary mismatch `shiftBoundaryAnchor` guards against — but
-// returns null (skip) for the legitimate, expected case of an off-week. It
-// deliberately doesn't search further ahead; if this week is off, next
-// week's cron run checks again on its own.
+// Resolves the instant to query on-call at. An override (rare manual
+// catch-up) always wins, bypassing the biweekly on/off-week check; it must
+// resolve to a future instant within MAX_OVERRIDE_DAYS_AHEAD. Otherwise this
+// is the routine cron path: it runs the day before the meeting, computing
+// "tomorrow" via `civilDateTimeIn`/`civilDatePlusDays` rather than raw UTC
+// arithmetic, since a cron's UTC firing instant can land on a different
+// calendar day than its `timeZone` civil date. Returns null (skip) on an
+// off-week; doesn't search further ahead since next week's cron run checks
+// again on its own.
 export const resolveMeetingInstant = (
   now: Date,
   meetingWeekday: number,
@@ -176,20 +154,10 @@ export const resolveMeetingInstant = (
   )
 }
 
-// Validates MEETING_BASE_DATE's format (the same hand-typed YYYY-MM-DD check
-// as MEETING_OVERRIDE_DATE — without it, a malformed value like "2026-02-31"
-// produces a confusing "falls on weekday NaN" error instead of a clear
-// format complaint) and returns the canonical (trimmed) string to use
-// downstream.
-//
-// isOffWeek's parity math assumes `baseDate` and any date it's compared
-// against fall on the same weekday, so they're always an exact multiple of
-// 7 days apart (see the comment on isOffWeek in biweekly.ts). That's only
-// actually true if baseDate falls on MEETING_WEEKDAY — an assumption that
-// meeting-weekday and base-date, as independent workflow inputs, don't
-// enforce on their own. Fail loudly here rather than silently computing the
-// wrong on/off-week parity if the meeting day ever changes without updating
-// baseDate to match.
+// isOffWeek's parity math (biweekly.ts) assumes baseDate falls on
+// meetingWeekday — an invariant these two independent inputs don't enforce
+// on their own, so fail loudly here instead of silently computing the wrong
+// parity.
 const requireValidBaseDate = (
   rawBaseDate: string,
   meetingWeekday: number
@@ -226,17 +194,10 @@ export const main = async (): Promise<void> => {
     max: 59,
   })
   const rawBaseDate = requireEnv("MEETING_BASE_DATE")
-  // Only set for a rare manual catch-up run — see resolveMeetingInstant.
-  // Trimmed before the truthiness check so a whitespace-only value (e.g. a
-  // blank workflow_dispatch input) falls through to the routine path
-  // instead of being treated as "an override is set."
+  // Trimmed so a blank workflow_dispatch input doesn't count as "set."
   const overrideDate = process.env.MEETING_OVERRIDE_DATE?.trim() || undefined
-  // MEETING_BASE_DATE is still required to be present either way, but its
-  // format/weekday validity only matters on the routine path — the override
-  // path never touches baseDate at all (resolveMeetingInstant skips the
-  // biweekly parity check entirely once overrideDate is set), so a
-  // base-date/weekday drift shouldn't block an otherwise-valid manual
-  // catch-up run.
+  // The override path never touches baseDate, so a base-date/weekday drift
+  // shouldn't block an otherwise-valid manual catch-up run.
   const baseDate = overrideDate
     ? rawBaseDate
     : requireValidBaseDate(rawBaseDate, meetingWeekday)

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -77,7 +77,10 @@ const parseOverrideDate = (
 //
 // If `overrideDate` is supplied (a rare manual catch-up run), targets that
 // date directly — an explicit override always means "run now," bypassing
-// the biweekly on/off-week check entirely.
+// the biweekly on/off-week check entirely. Throws if it resolves to an
+// instant that isn't strictly in the future, since a past override would
+// otherwise silently query on-call for, and post a facilitator notice about,
+// a meeting that's already happened.
 //
 // Otherwise, this is the routine cron path: it always runs the day before
 // the meeting, in `timeZone` civil time. "Tomorrow" is computed via
@@ -102,7 +105,7 @@ export const resolveMeetingInstant = (
 ): Date | null => {
   if (overrideDate) {
     const { year, month, day } = parseOverrideDate(overrideDate)
-    return zonedTimeToUtc(
+    const overrideInstant = zonedTimeToUtc(
       year,
       month,
       day,
@@ -111,6 +114,14 @@ export const resolveMeetingInstant = (
       0,
       timeZone
     )
+
+    if (overrideInstant.getTime() <= now.getTime()) {
+      throw new Error(
+        `MEETING_OVERRIDE_DATE "${overrideDate}" resolves to ${overrideInstant.toISOString()}, which is not after now (${now.toISOString()}). The override must target a future meeting.`
+      )
+    }
+
+    return overrideInstant
   }
 
   const today = civilDateTimeIn(timeZone, now)

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -49,12 +49,13 @@ const OVERRIDE_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 const parseOverrideDate = (
   raw: string
 ): { year: number; month: number; day: number } => {
-  if (!OVERRIDE_DATE_PATTERN.test(raw)) {
+  const trimmed = raw.trim()
+  if (!OVERRIDE_DATE_PATTERN.test(trimmed)) {
     throw new Error(
       `Invalid MEETING_OVERRIDE_DATE: "${raw}". Must be YYYY-MM-DD.`
     )
   }
-  const [year, month, day] = raw.split("-").map(Number)
+  const [year, month, day] = trimmed.split("-").map(Number)
 
   // Date.UTC silently rolls over out-of-range values (e.g. Feb 31 becomes
   // Mar 3) instead of rejecting them — round-tripping back to a string
@@ -64,7 +65,7 @@ const parseOverrideDate = (
   const roundTripString = `${roundTrip.getUTCFullYear()}-${String(
     roundTrip.getUTCMonth() + 1
   ).padStart(2, "0")}-${String(roundTrip.getUTCDate()).padStart(2, "0")}`
-  if (roundTripString !== raw) {
+  if (roundTripString !== trimmed) {
     throw new Error(
       `Invalid MEETING_OVERRIDE_DATE: "${raw}" is not a real calendar date.`
     )
@@ -129,7 +130,7 @@ export const resolveMeetingInstant = (
 
   if (tomorrow.weekday !== meetingWeekday) {
     throw new Error(
-      `resolveMeetingInstant expected tomorrow (in ${timeZone}) to be weekday ${meetingWeekday}, but it's ${tomorrow.weekday}. Check the cron schedule against MEETING_WEEKDAY.`
+      `resolveMeetingInstant expected tomorrow (in ${timeZone}) to be weekday ${meetingWeekday}, but it's ${tomorrow.weekday}. Check the cron schedule against MEETING_WEEKDAY, or set MEETING_OVERRIDE_DATE to target a specific date directly.`
     )
   }
 

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -1,0 +1,243 @@
+import * as fs from "fs"
+
+import { type BiweeklySchedule, isOffWeek } from "./biweekly"
+import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
+import { zonedTimeToUtc } from "./shift-boundary"
+
+const DEFAULT_TIME_ZONE = "America/New_York"
+const DEFAULT_MEETING_WEEKDAY = 4 // Thursday
+const DEFAULT_MEETING_HOUR = 11 // 11:30am ET (DST-aware via zonedTimeToUtc)
+const DEFAULT_MEETING_MINUTE = 30
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+const URLS = {
+  incidentReviewSchedule:
+    "https://www.notion.so/artsy/Incident-Reviews-725052225efc49e78532b13e166ba3c7",
+}
+
+export const buildPayload = (
+  mention: string | undefined,
+  onCallScheduleUrl: string
+): string => {
+  // currentOnCallUsers/usersToMentions can legitimately return nobody
+  // mentionable (a schedule gap, or every on-call participant missing a
+  // linked Slack account) — post an explicit notice instead of staying
+  // silent.
+  const text = mention
+    ? `${mention} :wave:, based on the <${onCallScheduleUrl}|on-call schedule> you've been selected to _prepare for and facilitate_ the upcoming Incident Review meeting! :tada:\nCheck out the <${URLS.incidentReviewSchedule}|Incident Review Schedule> for more information and the next steps.`
+    : `:warning: A facilitator should be picked for the upcoming Incident Review meeting, but nobody on the <${onCallScheduleUrl}|on-call schedule> can be reached on Slack (no linked account).`
+
+  return JSON.stringify({
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text,
+        },
+      },
+    ],
+  })
+}
+
+interface CivilDate {
+  year: number
+  month: number // 1-12
+  day: number
+  weekday: number // 0 (Sun) - 6 (Sat), Date#getUTCDay convention
+}
+
+// Steps forward in UTC calendar days, not the meeting's actual ET civil day
+// — a deliberate simplification, not an oversight. It's safe because the
+// real triggers (14:00 UTC cron, or a manual run during business hours) are
+// always mid-morning ET or later, nowhere near the UTC/ET day boundary, so
+// the two calendars never disagree here.
+const civilDatePlusDays = (now: Date, days: number): CivilDate => {
+  const shifted = new Date(now.getTime() + days * MS_PER_DAY)
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1,
+    day: shifted.getUTCDate(),
+    weekday: shifted.getUTCDay(),
+  }
+}
+
+const civilDateString = (date: CivilDate): string =>
+  `${date.year}-${String(date.month).padStart(2, "0")}-${String(
+    date.day
+  ).padStart(2, "0")}`
+
+// Scans offset = 1..lookaheadDays days ahead of `now` (the meeting is always
+// at least a day out from when this runs, whether by cron or manual
+// dispatch) for the next date that either matches the regular biweekly
+// on-week cadence of `meetingWeekday`, or is listed in `schedule.exceptions`
+// (a deliberate catch-up review, any weekday). Returns the meeting's UTC
+// instant — DST-aware via `zonedTimeToUtc` — or null if nothing qualifies
+// within the window.
+export const findMeetingInstant = (
+  now: Date,
+  meetingWeekday: number,
+  meetingHour: number,
+  meetingMinute: number,
+  schedule: BiweeklySchedule,
+  lookaheadDays: number,
+  timeZone: string = DEFAULT_TIME_ZONE
+): Date | null => {
+  for (let offset = 1; offset <= lookaheadDays; offset++) {
+    const candidate = civilDatePlusDays(now, offset)
+    const dateString = civilDateString(candidate)
+    const candidateMidnightUtc = new Date(
+      Date.UTC(candidate.year, candidate.month - 1, candidate.day)
+    )
+
+    const isException = schedule.exceptions.includes(dateString)
+    const isRegularOnWeekMeetingDay =
+      candidate.weekday === meetingWeekday &&
+      !isOffWeek(schedule, candidateMidnightUtc)
+
+    if (isException || isRegularOnWeekMeetingDay) {
+      return zonedTimeToUtc(
+        candidate.year,
+        candidate.month,
+        candidate.day,
+        meetingHour,
+        meetingMinute,
+        0,
+        timeZone
+      )
+    }
+  }
+
+  return null
+}
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} env var is not set.`)
+  }
+  return value
+}
+
+const readIntEnv = (
+  name: string,
+  defaultValue: number,
+  range: { min: number; max: number }
+): number => {
+  const raw = process.env[name]
+  const value = raw ? Number.parseInt(raw, 10) : defaultValue
+
+  if (Number.isNaN(value) || value < range.min || value > range.max) {
+    throw new Error(
+      `Invalid ${name}: "${raw}". Must be an integer between ${range.min} and ${range.max}.`
+    )
+  }
+
+  return value
+}
+
+const requireIntEnv = (
+  name: string,
+  range: { min: number; max: number }
+): number => {
+  const raw = requireEnv(name)
+  const value = Number.parseInt(raw, 10)
+
+  if (Number.isNaN(value) || value < range.min || value > range.max) {
+    throw new Error(
+      `Invalid ${name}: "${raw}". Must be an integer between ${range.min} and ${range.max}.`
+    )
+  }
+
+  return value
+}
+
+const parseDates = (raw: string): BiweeklySchedule => {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    throw new Error(`Invalid DATES env var: ${error}`)
+  }
+
+  const { baseDate, exceptions } = (parsed ?? {}) as Partial<BiweeklySchedule>
+  if (typeof baseDate !== "string" || !Array.isArray(exceptions)) {
+    throw new Error(
+      "Invalid DATES env var: expected JSON { baseDate: string, exceptions: string[] }."
+    )
+  }
+
+  return { baseDate, exceptions }
+}
+
+export const main = async (): Promise<void> => {
+  const apiKey = requireEnv("INCIDENT_IO_API_KEY")
+  const scheduleId = requireEnv("SCHEDULE_ID")
+  const meetingWeekday = readIntEnv(
+    "MEETING_WEEKDAY",
+    DEFAULT_MEETING_WEEKDAY,
+    { min: 0, max: 6 }
+  )
+  const meetingHour = readIntEnv("MEETING_HOUR", DEFAULT_MEETING_HOUR, {
+    min: 0,
+    max: 23,
+  })
+  const meetingMinute = readIntEnv("MEETING_MINUTE", DEFAULT_MEETING_MINUTE, {
+    min: 0,
+    max: 59,
+  })
+  // Cron and manual-dispatch runs pass their own literal value here — cron
+  // only ever needs to see 1 day ahead (the regular day-before-meeting
+  // check); a rare manual catch-up run needs enough slack to reach an
+  // off-week exception date on any weekday (e.g. triggered the Friday
+  // before a Monday catch-up).
+  const lookaheadDays = requireIntEnv("MEETING_LOOKAHEAD_DAYS", {
+    min: 1,
+    max: 13,
+  })
+  const schedule = parseDates(requireEnv("DATES"))
+
+  const meetingInstant = findMeetingInstant(
+    new Date(),
+    meetingWeekday,
+    meetingHour,
+    meetingMinute,
+    schedule,
+    lookaheadDays
+  )
+
+  if (!meetingInstant) {
+    console.log(
+      "facilitate-incident-review: no qualifying Incident Review within the lookahead window — skipping."
+    )
+    return
+  }
+
+  const users = await currentOnCallUsers(apiKey, scheduleId, meetingInstant)
+  const mentions = usersToMentions(users)
+  const facilitatorMention =
+    mentions.length > 0
+      ? mentions[Math.floor(Math.random() * mentions.length)]
+      : undefined
+
+  const payload = buildPayload(facilitatorMention, scheduleUrl(scheduleId))
+
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (outputPath) {
+    const delimiter = `EOF_${Date.now()}`
+    fs.appendFileSync(
+      outputPath,
+      `payload<<${delimiter}\n${payload}\n${delimiter}\n`
+    )
+  } else {
+    console.log(payload)
+  }
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -2,14 +2,16 @@ import * as fs from "fs"
 
 import { isOffWeek } from "./biweekly"
 import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
-import { zonedTimeToUtc } from "./shift-boundary"
+import {
+  civilDatePlusDays,
+  civilDateTimeIn,
+  zonedTimeToUtc,
+} from "./shift-boundary"
 
 const DEFAULT_TIME_ZONE = "America/New_York"
 const DEFAULT_MEETING_WEEKDAY = 4 // Thursday
 const DEFAULT_MEETING_HOUR = 11 // 11:30am ET (DST-aware via zonedTimeToUtc)
 const DEFAULT_MEETING_MINUTE = 30
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000
 
 const URLS = {
   incidentReviewSchedule:
@@ -62,10 +64,17 @@ const parseOverrideDate = (
 // the biweekly on/off-week check entirely.
 //
 // Otherwise, this is the routine cron path: it always runs the day before
-// the meeting, so it checks tomorrow specifically, returning null (skip)
-// unless tomorrow is both `meetingWeekday` and an on-week. It deliberately
-// doesn't search further ahead — if this week is off, next week's cron run
-// checks again on its own.
+// the meeting, in `timeZone` civil time. "Tomorrow" is computed via
+// `civilDateTimeIn`/`civilDatePlusDays` rather than raw UTC arithmetic,
+// because a cron's UTC firing instant can already be on a different UTC
+// calendar date than its `timeZone` civil date (e.g. a cron meant for
+// "Wednesday evening ET" fires at 2am UTC Thursday) — naive UTC-day-plus-one
+// would compound that offset instead of correcting for it. Throws if
+// tomorrow isn't `meetingWeekday` at all — the same class of misconfigured
+// cron-vs-boundary mismatch `shiftBoundaryAnchor` guards against — but
+// returns null (skip) for the legitimate, expected case of an off-week. It
+// deliberately doesn't search further ahead; if this week is off, next
+// week's cron run checks again on its own.
 export const resolveMeetingInstant = (
   now: Date,
   meetingWeekday: number,
@@ -88,24 +97,27 @@ export const resolveMeetingInstant = (
     )
   }
 
-  const tomorrow = new Date(now.getTime() + MS_PER_DAY)
-  if (tomorrow.getUTCDay() !== meetingWeekday) {
-    return null
+  const today = civilDateTimeIn(timeZone, now)
+  const tomorrow = civilDatePlusDays(timeZone, today, 1)
+
+  if (tomorrow.weekday !== meetingWeekday) {
+    throw new Error(
+      `resolveMeetingInstant expected tomorrow (in ${timeZone}) to be weekday ${meetingWeekday}, but it's ${tomorrow.weekday}. Check the cron schedule against MEETING_WEEKDAY.`
+    )
   }
 
-  const year = tomorrow.getUTCFullYear()
-  const month = tomorrow.getUTCMonth() + 1
-  const day = tomorrow.getUTCDate()
-  const midnightUtc = new Date(Date.UTC(year, month - 1, day))
+  const midnightUtc = new Date(
+    Date.UTC(tomorrow.year, tomorrow.month - 1, tomorrow.day)
+  )
 
   if (isOffWeek(baseDate, midnightUtc)) {
     return null
   }
 
   return zonedTimeToUtc(
-    year,
-    month,
-    day,
+    tomorrow.year,
+    tomorrow.month,
+    tomorrow.day,
     meetingHour,
     meetingMinute,
     0,

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -171,6 +171,29 @@ const parseDates = (raw: string): BiweeklySchedule => {
   return { baseDate, exceptions }
 }
 
+// isOffWeek's parity math assumes `baseDate` and any date it's compared
+// against fall on the same weekday, so they're always an exact multiple of
+// 7 days apart (see the comment on isOffWeek in biweekly.ts). That's only
+// actually true if baseDate falls on MEETING_WEEKDAY — an assumption that
+// meeting-weekday and DATES, as independent workflow inputs, don't enforce
+// on their own. Fail loudly here rather than silently computing the wrong
+// on/off-week parity if the meeting day ever changes without updating
+// baseDate to match.
+const requireBaseDateMatchesMeetingWeekday = (
+  schedule: BiweeklySchedule,
+  meetingWeekday: number
+): void => {
+  const baseDateWeekday = new Date(
+    `${schedule.baseDate}T00:00:00Z`
+  ).getUTCDay()
+
+  if (baseDateWeekday !== meetingWeekday) {
+    throw new Error(
+      `DATES.baseDate ("${schedule.baseDate}") falls on weekday ${baseDateWeekday}, but MEETING_WEEKDAY is ${meetingWeekday}. baseDate must fall on the same weekday as the configured meeting day — if the meeting day changed, update baseDate to a date on the new weekday too.`
+    )
+  }
+}
+
 export const main = async (): Promise<void> => {
   const apiKey = requireEnv("INCIDENT_IO_API_KEY")
   const scheduleId = requireEnv("SCHEDULE_ID")
@@ -197,6 +220,7 @@ export const main = async (): Promise<void> => {
     max: 13,
   })
   const schedule = parseDates(requireEnv("DATES"))
+  requireBaseDateMatchesMeetingWeekday(schedule, meetingWeekday)
 
   const meetingInstant = findMeetingInstant(
     new Date(),

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -54,6 +54,21 @@ const parseOverrideDate = (
     )
   }
   const [year, month, day] = raw.split("-").map(Number)
+
+  // Date.UTC silently rolls over out-of-range values (e.g. Feb 31 becomes
+  // Mar 3) instead of rejecting them — round-tripping back to a string
+  // catches a typo in this hand-typed, workflow_dispatch-entered value that
+  // the regex above can't.
+  const roundTrip = new Date(Date.UTC(year, month - 1, day))
+  const roundTripString = `${roundTrip.getUTCFullYear()}-${String(
+    roundTrip.getUTCMonth() + 1
+  ).padStart(2, "0")}-${String(roundTrip.getUTCDate()).padStart(2, "0")}`
+  if (roundTripString !== raw) {
+    throw new Error(
+      `Invalid MEETING_OVERRIDE_DATE: "${raw}" is not a real calendar date.`
+    )
+  }
+
   return { year, month, day }
 }
 

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs"
 
-import { type BiweeklySchedule, isOffWeek } from "./biweekly"
+import { isOffWeek } from "./biweekly"
 import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
 import { zonedTimeToUtc } from "./shift-boundary"
 
@@ -41,75 +41,76 @@ export const buildPayload = (
   })
 }
 
-interface CivilDate {
-  year: number
-  month: number // 1-12
-  day: number
-  weekday: number // 0 (Sun) - 6 (Sat), Date#getUTCDay convention
-}
+const OVERRIDE_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 
-// Steps forward in UTC calendar days, not the meeting's actual ET civil day
-// — a deliberate simplification, not an oversight. It's safe because the
-// real triggers (14:00 UTC cron, or a manual run during business hours) are
-// always mid-morning ET or later, nowhere near the UTC/ET day boundary, so
-// the two calendars never disagree here.
-const civilDatePlusDays = (now: Date, days: number): CivilDate => {
-  const shifted = new Date(now.getTime() + days * MS_PER_DAY)
-  return {
-    year: shifted.getUTCFullYear(),
-    month: shifted.getUTCMonth() + 1,
-    day: shifted.getUTCDate(),
-    weekday: shifted.getUTCDay(),
+const parseOverrideDate = (
+  raw: string
+): { year: number; month: number; day: number } => {
+  if (!OVERRIDE_DATE_PATTERN.test(raw)) {
+    throw new Error(
+      `Invalid MEETING_OVERRIDE_DATE: "${raw}". Must be YYYY-MM-DD.`
+    )
   }
+  const [year, month, day] = raw.split("-").map(Number)
+  return { year, month, day }
 }
 
-const civilDateString = (date: CivilDate): string =>
-  `${date.year}-${String(date.month).padStart(2, "0")}-${String(
-    date.day
-  ).padStart(2, "0")}`
-
-// Scans offset = 1..lookaheadDays days ahead of `now` (the meeting is always
-// at least a day out from when this runs, whether by cron or manual
-// dispatch) for the next date that either matches the regular biweekly
-// on-week cadence of `meetingWeekday`, or is listed in `schedule.exceptions`
-// (a deliberate catch-up review, any weekday). Returns the meeting's UTC
-// instant — DST-aware via `zonedTimeToUtc` — or null if nothing qualifies
-// within the window.
-export const findMeetingInstant = (
+// Resolves the instant to query on-call at.
+//
+// If `overrideDate` is supplied (a rare manual catch-up run), targets that
+// date directly — an explicit override always means "run now," bypassing
+// the biweekly on/off-week check entirely.
+//
+// Otherwise, this is the routine cron path: it always runs the day before
+// the meeting, so it checks tomorrow specifically, returning null (skip)
+// unless tomorrow is both `meetingWeekday` and an on-week. It deliberately
+// doesn't search further ahead — if this week is off, next week's cron run
+// checks again on its own.
+export const resolveMeetingInstant = (
   now: Date,
   meetingWeekday: number,
   meetingHour: number,
   meetingMinute: number,
-  schedule: BiweeklySchedule,
-  lookaheadDays: number,
+  baseDate: string,
+  overrideDate: string | undefined,
   timeZone: string = DEFAULT_TIME_ZONE
 ): Date | null => {
-  for (let offset = 1; offset <= lookaheadDays; offset++) {
-    const candidate = civilDatePlusDays(now, offset)
-    const dateString = civilDateString(candidate)
-    const candidateMidnightUtc = new Date(
-      Date.UTC(candidate.year, candidate.month - 1, candidate.day)
+  if (overrideDate) {
+    const { year, month, day } = parseOverrideDate(overrideDate)
+    return zonedTimeToUtc(
+      year,
+      month,
+      day,
+      meetingHour,
+      meetingMinute,
+      0,
+      timeZone
     )
-
-    const isException = schedule.exceptions.includes(dateString)
-    const isRegularOnWeekMeetingDay =
-      candidate.weekday === meetingWeekday &&
-      !isOffWeek(schedule, candidateMidnightUtc)
-
-    if (isException || isRegularOnWeekMeetingDay) {
-      return zonedTimeToUtc(
-        candidate.year,
-        candidate.month,
-        candidate.day,
-        meetingHour,
-        meetingMinute,
-        0,
-        timeZone
-      )
-    }
   }
 
-  return null
+  const tomorrow = new Date(now.getTime() + MS_PER_DAY)
+  if (tomorrow.getUTCDay() !== meetingWeekday) {
+    return null
+  }
+
+  const year = tomorrow.getUTCFullYear()
+  const month = tomorrow.getUTCMonth() + 1
+  const day = tomorrow.getUTCDate()
+  const midnightUtc = new Date(Date.UTC(year, month - 1, day))
+
+  if (isOffWeek(baseDate, midnightUtc)) {
+    return null
+  }
+
+  return zonedTimeToUtc(
+    year,
+    month,
+    day,
+    meetingHour,
+    meetingMinute,
+    0,
+    timeZone
+  )
 }
 
 const requireEnv = (name: string): string => {
@@ -137,59 +138,23 @@ const readIntEnv = (
   return value
 }
 
-const requireIntEnv = (
-  name: string,
-  range: { min: number; max: number }
-): number => {
-  const raw = requireEnv(name)
-  const value = Number.parseInt(raw, 10)
-
-  if (Number.isNaN(value) || value < range.min || value > range.max) {
-    throw new Error(
-      `Invalid ${name}: "${raw}". Must be an integer between ${range.min} and ${range.max}.`
-    )
-  }
-
-  return value
-}
-
-const parseDates = (raw: string): BiweeklySchedule => {
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(raw)
-  } catch (error) {
-    throw new Error(`Invalid DATES env var: ${error}`)
-  }
-
-  const { baseDate, exceptions } = (parsed ?? {}) as Partial<BiweeklySchedule>
-  if (typeof baseDate !== "string" || !Array.isArray(exceptions)) {
-    throw new Error(
-      "Invalid DATES env var: expected JSON { baseDate: string, exceptions: string[] }."
-    )
-  }
-
-  return { baseDate, exceptions }
-}
-
 // isOffWeek's parity math assumes `baseDate` and any date it's compared
 // against fall on the same weekday, so they're always an exact multiple of
 // 7 days apart (see the comment on isOffWeek in biweekly.ts). That's only
 // actually true if baseDate falls on MEETING_WEEKDAY — an assumption that
-// meeting-weekday and DATES, as independent workflow inputs, don't enforce
-// on their own. Fail loudly here rather than silently computing the wrong
-// on/off-week parity if the meeting day ever changes without updating
+// meeting-weekday and base-date, as independent workflow inputs, don't
+// enforce on their own. Fail loudly here rather than silently computing the
+// wrong on/off-week parity if the meeting day ever changes without updating
 // baseDate to match.
 const requireBaseDateMatchesMeetingWeekday = (
-  schedule: BiweeklySchedule,
+  baseDate: string,
   meetingWeekday: number
 ): void => {
-  const baseDateWeekday = new Date(
-    `${schedule.baseDate}T00:00:00Z`
-  ).getUTCDay()
+  const baseDateWeekday = new Date(`${baseDate}T00:00:00Z`).getUTCDay()
 
   if (baseDateWeekday !== meetingWeekday) {
     throw new Error(
-      `DATES.baseDate ("${schedule.baseDate}") falls on weekday ${baseDateWeekday}, but MEETING_WEEKDAY is ${meetingWeekday}. baseDate must fall on the same weekday as the configured meeting day — if the meeting day changed, update baseDate to a date on the new weekday too.`
+      `MEETING_BASE_DATE ("${baseDate}") falls on weekday ${baseDateWeekday}, but MEETING_WEEKDAY is ${meetingWeekday}. baseDate must fall on the same weekday as the configured meeting day — if the meeting day changed, update baseDate to a date on the new weekday too.`
     )
   }
 }
@@ -210,30 +175,23 @@ export const main = async (): Promise<void> => {
     min: 0,
     max: 59,
   })
-  // Cron and manual-dispatch runs pass their own literal value here — cron
-  // only ever needs to see 1 day ahead (the regular day-before-meeting
-  // check); a rare manual catch-up run needs enough slack to reach an
-  // off-week exception date on any weekday (e.g. triggered the Friday
-  // before a Monday catch-up).
-  const lookaheadDays = requireIntEnv("MEETING_LOOKAHEAD_DAYS", {
-    min: 1,
-    max: 13,
-  })
-  const schedule = parseDates(requireEnv("DATES"))
-  requireBaseDateMatchesMeetingWeekday(schedule, meetingWeekday)
+  const baseDate = requireEnv("MEETING_BASE_DATE")
+  requireBaseDateMatchesMeetingWeekday(baseDate, meetingWeekday)
+  // Only set for a rare manual catch-up run — see resolveMeetingInstant.
+  const overrideDate = process.env.MEETING_OVERRIDE_DATE || undefined
 
-  const meetingInstant = findMeetingInstant(
+  const meetingInstant = resolveMeetingInstant(
     new Date(),
     meetingWeekday,
     meetingHour,
     meetingMinute,
-    schedule,
-    lookaheadDays
+    baseDate,
+    overrideDate
   )
 
   if (!meetingInstant) {
     console.log(
-      "facilitate-incident-review: no qualifying Incident Review within the lookahead window — skipping."
+      "facilitate-incident-review: no qualifying Incident Review — skipping."
     )
     return
   }

--- a/scripts/on-call/facilitate-incident-review.ts
+++ b/scripts/on-call/facilitate-incident-review.ts
@@ -6,6 +6,7 @@ import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
 import {
   civilDatePlusDays,
   civilDateTimeIn,
+  MS_PER_DAY,
   zonedTimeToUtc,
 } from "./shift-boundary"
 
@@ -14,7 +15,6 @@ const DEFAULT_MEETING_WEEKDAY = 4 // Thursday
 const DEFAULT_MEETING_HOUR = 11 // 11:30am ET (DST-aware via zonedTimeToUtc)
 const DEFAULT_MEETING_MINUTE = 30
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000
 // Catch-ups are a near-term, days-to-weeks-out scenario — never months away —
 // so this also catches a hand-typed year typo (e.g. 2027 instead of 2026)
 // that the past-date check alone can't, since a typo in the future direction
@@ -225,15 +225,21 @@ export const main = async (): Promise<void> => {
     min: 0,
     max: 59,
   })
-  const baseDate = requireValidBaseDate(
-    requireEnv("MEETING_BASE_DATE"),
-    meetingWeekday
-  )
+  const rawBaseDate = requireEnv("MEETING_BASE_DATE")
   // Only set for a rare manual catch-up run — see resolveMeetingInstant.
   // Trimmed before the truthiness check so a whitespace-only value (e.g. a
   // blank workflow_dispatch input) falls through to the routine path
   // instead of being treated as "an override is set."
   const overrideDate = process.env.MEETING_OVERRIDE_DATE?.trim() || undefined
+  // MEETING_BASE_DATE is still required to be present either way, but its
+  // format/weekday validity only matters on the routine path — the override
+  // path never touches baseDate at all (resolveMeetingInstant skips the
+  // biweekly parity check entirely once overrideDate is set), so a
+  // base-date/weekday drift shouldn't block an otherwise-valid manual
+  // catch-up run.
+  const baseDate = overrideDate
+    ? rawBaseDate
+    : requireValidBaseDate(rawBaseDate, meetingWeekday)
 
   const meetingInstant = resolveMeetingInstant(
     new Date(),

--- a/scripts/on-call/next-on-call.ts
+++ b/scripts/on-call/next-on-call.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs"
 
+import { requireEnv, requireIntEnv } from "./env"
 import { nextOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
 import { nextShiftBoundaryInstant } from "./shift-boundary"
 
@@ -40,30 +41,6 @@ export const buildPayload = (
       },
     ],
   })
-}
-
-const requireEnv = (name: string): string => {
-  const value = process.env[name]
-  if (!value) {
-    throw new Error(`${name} env var is not set.`)
-  }
-  return value
-}
-
-const requireIntEnv = (
-  name: string,
-  range: { min: number; max: number }
-): number => {
-  const raw = requireEnv(name)
-  const value = Number.parseInt(raw, 10)
-
-  if (Number.isNaN(value) || value < range.min || value > range.max) {
-    throw new Error(
-      `Invalid ${name}: "${raw}". Must be an integer between ${range.min} and ${range.max}.`
-    )
-  }
-
-  return value
 }
 
 export const main = async (): Promise<void> => {

--- a/scripts/on-call/shift-boundary.ts
+++ b/scripts/on-call/shift-boundary.ts
@@ -22,7 +22,7 @@ export interface ShiftBoundary {
   timeZone?: string // IANA name, default "America/New_York"
 }
 
-interface CivilDateTime {
+export interface CivilDateTime {
   year: number
   month: number
   day: number
@@ -42,7 +42,10 @@ const WEEKDAY_INDEX: Record<string, number> = {
   Sat: 6,
 }
 
-const civilDateTimeIn = (timeZone: string, instant: Date): CivilDateTime => {
+export const civilDateTimeIn = (
+  timeZone: string,
+  instant: Date
+): CivilDateTime => {
   const formatter = new Intl.DateTimeFormat("en-US", {
     timeZone,
     weekday: "short",
@@ -151,7 +154,7 @@ export const shiftBoundaryAnchor = (
 // month/year rollovers are handled by `Date.UTC`'s normal overflow behavior,
 // and the DST offset lookup never lands near a transition's own boundary
 // hour (see `zonedTimeToUtc`'s caveat above).
-const civilDatePlusDays = (
+export const civilDatePlusDays = (
   timeZone: string,
   civil: Pick<CivilDateTime, "year" | "month" | "day">,
   days: number

--- a/scripts/on-call/shift-boundary.ts
+++ b/scripts/on-call/shift-boundary.ts
@@ -92,7 +92,7 @@ const utcOffsetMinutes = (timeZone: string, instant: Date): number => {
 }
 
 // Converts a wall-clock time in `timeZone` to the UTC instant it represents.
-const zonedTimeToUtc = (
+export const zonedTimeToUtc = (
   year: number,
   month: number,
   day: number,

--- a/scripts/on-call/shift-boundary.ts
+++ b/scripts/on-call/shift-boundary.ts
@@ -16,6 +16,8 @@ const DEFAULT_TIME_ZONE = "America/New_York"
 // match resolves to the outgoing shift rather than the incoming one.
 const BOUNDARY_SAFETY_MARGIN_MS = 1_000
 
+export const MS_PER_DAY = 24 * 60 * 60 * 1000
+
 export interface ShiftBoundary {
   weekday: number // 0 (Sun) - 6 (Sat), Date#getDay convention
   hour: number // 0-23, local time in `timeZone`

--- a/scripts/on-call/standup-reminder.ts
+++ b/scripts/on-call/standup-reminder.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs"
 
+import { readIntEnv, requireEnv } from "./env"
 import { currentOnCallUsers, scheduleUrl, usersToMentions } from "./incident-io"
 import { shiftBoundaryAnchor } from "./shift-boundary"
 
@@ -38,31 +39,6 @@ export const buildPayload = (
       },
     ],
   })
-}
-
-const requireEnv = (name: string): string => {
-  const value = process.env[name]
-  if (!value) {
-    throw new Error(`${name} env var is not set.`)
-  }
-  return value
-}
-
-const readIntEnv = (
-  name: string,
-  defaultValue: number,
-  range: { min: number; max: number }
-): number => {
-  const raw = process.env[name]
-  const value = raw ? Number.parseInt(raw, 10) : defaultValue
-
-  if (Number.isNaN(value) || value < range.min || value > range.max) {
-    throw new Error(
-      `Invalid ${name}: "${raw}". Must be an integer between ${range.min} and ${range.max}.`
-    )
-  }
-
-  return value
 }
 
 export const main = async (): Promise<void> => {


### PR DESCRIPTION
## Summary

Phase 3 of the Opsgenie → incident.io on-call migration (PHIRE-3295), following [standup-reminder](https://github.com/artsy/duchamp/pull/102) and [next-on-call](https://github.com/artsy/duchamp/pull/106). Adds a reusable workflow that posts a Slack notice picking a random on-call participant to facilitate the upcoming biweekly Incident Review meeting, replacing the old `artsy/cli` `scheduled:facilitate-incident-review` command.

- Queries incident.io for who's on-call **at the actual meeting instant** (not the day the workflow runs), so a schedule override added after the day-before notification is still correctly reflected in who gets picked.
- Incident Reviews run every other week — `base-date` anchors that cadence via exact day-level parity math (no drift regardless of age).
- A rare off-week catch-up review is handled via an explicit `override-date`, filled in at `workflow_dispatch` trigger time.
- Fails loudly at startup if `base-date`'s weekday doesn't match the configured meeting weekday, since the parity math silently breaks otherwise if the meeting day ever changes without updating `base-date` to match.

## Test plan

- [x] 70 unit tests passing across the `on-call` script suite (`yarn jest scripts/on-call/`)
- [x] Manually ran `facilitate-incident-review.ts` locally against the real incident.io API, both via the routine tomorrow-check path and the `MEETING_OVERRIDE_DATE` catch-up path — confirmed correct facilitator selection and payload output

Assisted-by: Claude:Sonnet-5 [Claude Code]