### PR TITLE
feat: add Datadog triage workflow

### DIFF
--- a/.github/workflows/daily-datadog-triage.yml
+++ b/.github/workflows/daily-datadog-triage.yml
@@ -1,0 +1,188 @@
+name: Daily Datadog Triage
+
+# Scans this repo's production errors in Datadog and opens at most ONE
+# pre-triaged GitHub issue. Read-only: the only write is `gh issue`. Fixes are
+# human-initiated in a separate session. Full rules live in the skill:
+# artsy/agent-tooling plugins/artsy-artnet/skills/datadog-triage.
+
+on:
+  workflow_call:
+    secrets:
+      anthropic-api-key:
+        description: "Anthropic API key for Claude Code"
+        required: true
+      dd-api-key:
+        description: "Datadog API key (DD_API_KEY)"
+        required: true
+      dd-app-key:
+        description: "Datadog Application key (DD_APP_KEY) — must be scoped apm_read + error_tracking_read"
+        required: true
+      triage-issues-token:
+        description: "Token with issues:write on this repo ONLY. No contents:write, no PR scope."
+        required: true
+    inputs:
+      dd-site:
+        description: "Datadog site (DD_SITE)."
+        default: "datadoghq.com"
+        required: false
+        type: string
+      model:
+        description: "Claude model. Sonnet by default; bump to claude-opus-5 if a repo's write-ups come out thin."
+        default: "claude-sonnet-5"
+        required: false
+        type: string
+      timeout-minutes:
+        description: "Maximum time for the whole job, setup included. Keep headroom — a timeout mid-run costs full token spend and files nothing."
+        default: 30
+        required: false
+        type: number
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    concurrency:
+      group: datadog-triage-${{ github.repository }}
+      # Queue rather than cancel: a cancel can land after the model has read
+      # Datadog but before `gh issue create`, paying full token cost for nothing.
+      cancel-in-progress: false
+    # Issue writes come from triage-issues-token, not GITHUB_TOKEN, so this
+    # job cannot escalate to contents or PR writes.
+    permissions:
+      contents: read
+    steps:
+      - name: Refuse to run against a public repo
+        # Queried via the API rather than github.event.repository.private: the
+        # event payload is minimal on `schedule`, where an absent field would
+        # render empty and fail this gate on every cron run.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Assigned on its own line so a failing `gh` (rate limit, outage) aborts
+          # here. Inside an `if` condition, set -e ignores the substitution's exit
+          # status and the empty result would be reported as "public repo".
+          IS_PRIVATE="$(gh repo view "$GITHUB_REPOSITORY" --json isPrivate --jq .isPrivate)"
+          if [ "$IS_PRIVATE" != "true" ]; then
+            echo "TRIAGE FAILED: datadog-triage is for private repos only." >&2
+            exit 1
+          fi
+
+      - name: Checkout target repo
+        # Shallow on purpose — the skill confirms root cause against current
+        # source. 50 keeps `git log`/`git blame` usable without cloning a
+        # five-figure commit history on every run.
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pup (Datadog CLI)
+        # Release tarball, not brew: Homebrew-on-Linux often builds from source,
+        # which is minutes per run for a binary Datadog already publishes.
+        # Note the org split: tap is datadog-labs, releases DataDog.
+        #
+        # Pinned by digest, not just version: a git tag and its release assets are
+        # mutable, so the version alone doesn't guarantee the same bytes — and this
+        # binary runs as root's install in a process holding the Datadog keys and
+        # the issues token. Recompute PUP_SHA256 whenever PUP_VERSION changes
+        # (the release publishes no checksums.txt to verify against).
+        env:
+          PUP_VERSION: "1.10.4"
+          PUP_SHA256: "9d99ca0229fb0c767c6f74e07a0efa3e12091e9cfc297757e190247d26b537c5"
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/pup.tar.gz" \
+            "https://github.com/DataDog/pup/releases/download/v${PUP_VERSION}/pup_${PUP_VERSION}_Linux_x86_64.tar.gz"
+          echo "$PUP_SHA256  $RUNNER_TEMP/pup.tar.gz" | sha256sum -c -
+          sudo tar -xzf "$RUNNER_TEMP/pup.tar.gz" -C /usr/local/bin pup
+          pup --version
+
+      - name: Pre-install Datadog agent skills (dd-pup, dd-logs, dd-apm)
+        # Pinned SHA, not `npx skills add`, which resolves both the CLI and the
+        # upstream repo at tip. Skills are instructions the model follows, so an
+        # upstream edit would change what this job does with no commit here.
+        env:
+          DD_SKILLS_SHA: "6a5635ac5fea33a22ca6a57d3bc903944f87fa70"
+        run: |
+          set -euo pipefail
+          git clone --filter=blob:none --no-checkout \
+            https://github.com/datadog-labs/agent-skills .dd-skills
+          git -C .dd-skills checkout --quiet "$DD_SKILLS_SHA"
+          mkdir -p "$HOME/.claude/skills"
+          cp -r .dd-skills/dd-pup .dd-skills/dd-logs .dd-skills/dd-apm \
+            "$HOME/.claude/skills/"
+          rm -rf .dd-skills
+
+      - name: Materialize read-only settings
+        # The skill is synced into the calling repo, so it arrives with the
+        # checkout — no credential needed to read a private agent-tooling from
+        # CI. The path is fixed, not an input: Claude Code only discovers skills
+        # under .claude/skills, so anywhere else loads nothing. Abort if it's
+        # absent rather than let Claude improvise without the skill's rules.
+        #
+        # A PreToolUse hook whose command doesn't exist is not an error, so an
+        # unsubstituted __SKILL_DIR__ fails OPEN — hence the grep guard.
+        run: |
+          set -euo pipefail
+          SKILL_DIR="$GITHUB_WORKSPACE/.claude/skills/datadog-triage"
+          if [ ! -f "$SKILL_DIR/SKILL.md" ]; then
+            echo "TRIAGE FAILED: no datadog-triage skill at .claude/skills/datadog-triage." >&2
+            echo "It is synced from artsy/agent-tooling (plugins/artsy-artnet/skills/datadog-triage)" >&2
+            echo "— see the daily-datadog-triage.yml section in duchamp's docs/actions.md." >&2
+            exit 1
+          fi
+          SETTINGS="$RUNNER_TEMP/triage-settings.json"
+          sed "s|__SKILL_DIR__|$SKILL_DIR|g" \
+            "$SKILL_DIR/reference/settings.example.json" > "$SETTINGS"
+          if grep -q '__SKILL_DIR__' "$SETTINGS"; then
+            echo "TRIAGE FAILED: __SKILL_DIR__ unsubstituted." >&2
+            exit 1
+          fi
+          chmod +x "$SKILL_DIR/reference/hooks/block-secret-reads.sh"
+          echo "TRIAGE_SETTINGS=$SETTINGS" >> "$GITHUB_ENV"
+
+          # claude_args takes precedence over --settings for permissions, so the
+          # tool policy has to be restated as flags. Derive it from the same file
+          # rather than duplicating the lists across two repos, where they'd drift
+          # unnoticed. An empty list would silently mean "no restrictions".
+          ALLOWED="$(jq -er '.permissions.allow | join(",")' "$SETTINGS")"
+          DENIED="$(jq -er '.permissions.deny | join(",")' "$SETTINGS")"
+          if [ -z "$ALLOWED" ] || [ -z "$DENIED" ]; then
+            echo "TRIAGE FAILED: empty allow/deny list in settings.example.json." >&2
+            exit 1
+          fi
+          echo "TRIAGE_ALLOWED_TOOLS=$ALLOWED" >> "$GITHUB_ENV"
+          echo "TRIAGE_DISALLOWED_TOOLS=$DENIED" >> "$GITHUB_ENV"
+
+      - name: Run Datadog triage (read-only)
+        uses: anthropics/claude-code-action@v1
+        env:
+          DD_API_KEY: ${{ secrets.dd-api-key }}
+          DD_APP_KEY: ${{ secrets.dd-app-key }}
+          DD_SITE: ${{ inputs.dd-site }}
+          GH_TOKEN: ${{ secrets.triage-issues-token }}
+        with:
+          anthropic_api_key: ${{ secrets.anthropic-api-key }}
+          # The action grants no Bash by default and documents claude_args as
+          # taking precedence over settings, so the tool policy has to be stated
+          # here or pup never runs. Both flags are derived from the skill's
+          # settings.example.json in the step above — that file is the one source
+          # of truth. --settings still carries the PreToolUse hook.
+          claude_args: >-
+            --model ${{ inputs.model }}
+            --settings ${{ env.TRIAGE_SETTINGS }}
+            --allowedTools "${{ env.TRIAGE_ALLOWED_TOOLS }}"
+            --disallowedTools "${{ env.TRIAGE_DISALLOWED_TOOLS }}"
+          prompt: |
+            Use the `datadog-triage` skill. Follow it exactly.
+
+            REPO: ${{ github.repository }}
+
+            `pup` is authenticated via DD_API_KEY / DD_APP_KEY / DD_SITE in the
+            environment, and dd-pup / dd-logs / dd-apm are pre-installed. `gh` is
+            authenticated with issues:write and nothing else.

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -16,6 +16,7 @@ This document provides detailed reference information for all GitHub Actions ava
 | `incident-standup-reminder.yml`      | Remind on-call to run standup  | For scheduled Slack standup reminders |
 | `incident-next-on-call.yml`          | Remind engineers of an upcoming on-call shift | For scheduled Slack next-on-call reminders |
 | `incident-facilitate-review.yml`     | Pick a random facilitator for the Incident Review | For scheduled Slack Incident Review facilitator selection |
+| `daily-datadog-triage.yml`           | Open one pre-triaged issue from Datadog errors | For private repos triaging production errors |
 
 ## Action Reference
 
@@ -538,6 +539,53 @@ joule's real workflow sources these values from repo vars instead of literals, s
 
 ---
 
+### daily-datadog-triage.yml
+
+**Purpose**: Scan a repo's production errors in Datadog and open at most **one** pre-triaged GitHub issue per run
+
+**Use Case**: Private repos that want a daily shortlist of production errors. Read-only — never edits code or opens a PR; fixes stay human-initiated
+
+Copy `templates/run-daily-datadog-triage.yml` into the calling repo — it carries the schedule, secret names, and setup notes.
+
+```yaml
+jobs:
+  triage:
+    uses: artsy/duchamp/.github/workflows/daily-datadog-triage.yml@main
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      dd-api-key: ${{ secrets.DD_TRIAGE_API_KEY }}
+      dd-app-key: ${{ secrets.DD_TRIAGE_APP_KEY }}
+      triage-issues-token: ${{ secrets.TRIAGE_ISSUES_TOKEN }}
+```
+
+**Features:**
+
+- Aborts on public repos — write-ups quote stack traces and production data
+- Deny-by-default tools: `pup`, read-only `git`, `gh issue`/`gh label`, plus a hook blocking credential reads. Issue writes use `triage-issues-token`; `GITHUB_TOKEN` gets only `contents: read`
+- `pup` release and the `datadog-labs/agent-skills` SHA are pinned, so a scheduled run can't pick up new tooling or new model instructions
+- Triage rules live in the skill, not this workflow
+
+**One-time setup in the calling repo:**
+
+1. Sync the `datadog-triage` skill to `.claude/skills/datadog-triage/` (fixed path — the run aborts if it's missing). Source of truth: [artsy/agent-tooling](https://github.com/artsy/agent-tooling) `plugins/artsy-artnet/skills/datadog-triage`; edit it there, never downstream.
+2. Create the `triage`, `triage/fixed`, and `triage/rejected` labels.
+3. Add the secrets below, and list the repo's Datadog services in its `CLAUDE.md`.
+
+**Inputs:**
+
+- `dd-site` (optional): Datadog site. Default: `datadoghq.com`
+- `model` (optional): Default `claude-sonnet-5`; bump to `claude-opus-5` if write-ups come out thin
+- `timeout-minutes` (optional): Whole-job timeout. Default: `30`
+
+**Secrets:**
+
+- `anthropic-api-key` (required): Anthropic API key for Claude Code
+- `dd-api-key` (required): Datadog API key
+- `dd-app-key` (required): Datadog app key, scoped `apm_read` + `error_tracking_read` — the run aborts in preflight without the latter
+- `triage-issues-token` (required): `issues:write` on the calling repo only — no `contents:write`, no PR scope
+
+---
+
 ## Reusable Action
 
 ### setup-and-install
@@ -581,6 +629,7 @@ joule's real workflow sources these values from repo vars instead of literals, s
 | Scheduled on-call Slack reminders | `incident-standup-reminder.yml`   | Sources current on-call from incident.io |
 | Scheduled upcoming on-call reminders | `incident-next-on-call.yml`    | Notifies engineers ahead of their shift starting |
 | Scheduled Incident Review facilitator selection | `incident-facilitate-review.yml` | Picks a random on-call participant to facilitate |
+| Daily production error triage    | `daily-datadog-triage.yml`           | Private repos only; opens one issue per run |
 | Custom workflows                | `setup-and-install` action           | Use as a step in custom workflows    |
 
 ## Security Considerations

--- a/templates/run-daily-datadog-triage.yml
+++ b/templates/run-daily-datadog-triage.yml
@@ -1,0 +1,38 @@
+# Copy into a target repo as `.github/workflows/run-daily-datadog-triage.yml`.
+#
+# Scans this repo's production errors in Datadog and opens at most one
+# pre-triaged issue. Read-only — never edits code or opens a PR.
+#
+# Required secrets. The DD_TRIAGE_* names are deliberately scoped to this job —
+# don't point them at a general-purpose Datadog key, which would hand a
+# read-only job credentials it doesn't need.
+#   ANTHROPIC_API_KEY    - Claude Code API key
+#   DD_TRIAGE_API_KEY    - Datadog API key
+#   DD_TRIAGE_APP_KEY    - Datadog app key, scoped apm_read + error_tracking_read
+#                          (without error_tracking_read the run aborts in preflight)
+#   TRIAGE_ISSUES_TOKEN  - issues:write on this repo only (GitHub's fine-grained token)
+#
+# One-time setup:
+#   - create the `triage`, `triage/fixed`, and `triage/rejected` labels
+#   - have the `datadog-triage` skill in `.claude/skills/datadog-triage/`. It is
+#     synced in from artsy/agent-tooling (private, so CI can't fetch it) — edit
+#     it there, never here. The run aborts if it's missing.
+name: Daily Datadog Triage
+
+on:
+  # Uncomment once a couple of manual runs look right.
+  # schedule:
+  #   - cron: "0 13 * * 1-5" # 13:00 UTC, weekdays
+  workflow_dispatch: {}
+
+jobs:
+  triage:
+    uses: artsy/duchamp/.github/workflows/daily-datadog-triage.yml@main
+    # Override the Datadog service list in this repo's CLAUDE.md, not here.
+    # with:
+    #   model: claude-opus-5
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      dd-api-key: ${{ secrets.DD_TRIAGE_API_KEY }}
+      dd-app-key: ${{ secrets.DD_TRIAGE_APP_KEY }}
+      triage-issues-token: ${{ secrets.TRIAGE_ISSUES_TOKEN }}


### PR DESCRIPTION
This adds a reusable workflow that looks at a repo's production errors in Datadog and opens a single pre-triaged GitHub issue for the top untracked crash, plus a copy-paste caller template for opting a repo in. 

It runs the `datadog-triage` skill from artsy/agent-tooling#10, pinned to the `artsy-artnet-v1.4.0`, so a skill edit can't quietly change what runs against production overnight. The job is read-only which means that its only write is `gh issue`, enforced by a deny by default settings file and a hook that blocks credential reads  (more about security in this artsy/agent-tooling#10). 

Assisted-by: Claude:Opus-5