### PR TITLE
fix: grant id-token for dd-triage

### DIFF
--- a/.github/workflows/daily-datadog-triage.yml
+++ b/.github/workflows/daily-datadog-triage.yml
@@ -50,6 +50,9 @@ jobs:
     # job cannot escalate to contents or PR writes.
     permissions:
       contents: read
+      # claude-code-action fetches an OIDC token on startup even when given an
+      # API key; without this the run dies before the prompt.
+      id-token: write
     steps:
       - name: Refuse to run against a public repo
         # Queried via the API rather than github.event.repository.private: the


### PR DESCRIPTION
This PR adds fix for oidc token generation.

<img width="886" height="526" alt="image" src="https://github.com/user-attachments/assets/f2e4c771-adba-42ae-9c42-577511b7cb68" />


Follow-up to https://github.com/artsy/duchamp/pull/111